### PR TITLE
[fix] Export all types from fetchBridgeImpl

### DIFF
--- a/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
+++ b/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
@@ -160,7 +160,7 @@ export class FetchBridgeImpl implements IHttpApiBridge {
         const urlParameterRegex = /\{[^\}]+\}/;
         let path = this.normalizeWithNoLeadingSlash(parameters.endpointPath);
         for (let pathArgument of parameters.pathArguments) {
-            pathArgument = pathArgument == null ? "" : pathArgument
+            pathArgument = pathArgument == null ? "" : pathArgument;
             path = path.replace(urlParameterRegex, encodeURIComponent(pathArgument));
         }
         return path;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
  */
 
 export { FetchBridgeImpl as DefaultHttpApiBridge } from "./httpApiBridge/fetchBridge/fetchBridgeImpl";
+export * from "./httpApiBridge/fetchBridge/fetchBridgeImpl";
 export * from "./httpApiBridge/fetchBridge/retryingFetch";
 export * from "./httpApiBridge/error";
 export * from "./httpApiBridge/httpApiBridge";


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
People would have to import types from deep in the file tree, usually causing tslint failures.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
People can now just import all types straight from `conjure-client`.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
fixes #11 