### PR TITLE
[improvement] support conjure primitives as header params

### DIFF
--- a/src/httpApiBridge/fetchBridge/__tests__/fetchBridgeImplTests.ts
+++ b/src/httpApiBridge/fetchBridge/__tests__/fetchBridgeImplTests.ts
@@ -259,6 +259,9 @@ describe("FetchBridgeImpl", () => {
             endpointPath: "a",
             headers: {
                 "Cache-Control": "max-age=60",
+                "boolean-header": true,
+                "null-header": null,
+                "number-header": 1,
             },
             method: "GET",
             pathArguments: [],
@@ -270,55 +273,9 @@ describe("FetchBridgeImpl", () => {
             contentType: "application/json",
             headers: {
                 "Cache-Control": "max-age=60",
+                "boolean-header": "true",
+                "number-header": "1",
             },
-            method: "GET",
-            responseMediaType: request.responseMediaType,
-        });
-        const expectedFetchResponse = createFetchResponse(mockedResponseData, 200);
-        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
-        await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
-    });
-
-    it("passes undefined headers", async () => {
-        const request: IHttpEndpointOptions = {
-            endpointName: "a",
-            endpointPath: "a",
-            headers: {
-                "Cache-Control": (undefined as any) as string,
-            },
-            method: "GET",
-            pathArguments: [],
-            queryArguments: {},
-            responseMediaType: MediaType.APPLICATION_JSON,
-        };
-        const expectedUrl = `${baseUrl}/a`;
-        const expectedFetchRequest = createFetchRequest({
-            contentType: MediaType.APPLICATION_JSON,
-            headers: {},
-            method: "GET",
-            responseMediaType: request.responseMediaType,
-        });
-        const expectedFetchResponse = createFetchResponse(mockedResponseData, 200);
-        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
-        await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
-    });
-
-    it("passes null headers", async () => {
-        const request: IHttpEndpointOptions = {
-            endpointName: "a",
-            endpointPath: "a",
-            headers: {
-                "Cache-Control": (null as any) as string,
-            },
-            method: "GET",
-            pathArguments: [],
-            queryArguments: {},
-            responseMediaType: MediaType.APPLICATION_JSON,
-        };
-        const expectedUrl = `${baseUrl}/a`;
-        const expectedFetchRequest = createFetchRequest({
-            contentType: "application/json",
-            headers: {},
             method: "GET",
             responseMediaType: request.responseMediaType,
         });

--- a/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
+++ b/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
@@ -72,17 +72,19 @@ export class FetchBridgeImpl implements IHttpApiBridge {
         const url = `${this.baseUrl}/${this.buildPath(params)}${this.buildQueryString(params)}`;
         const { data, headers = {}, method, requestMediaType, responseMediaType } = params;
         headers["Fetch-User-Agent"] = formatUserAgent(this.userAgent);
+        const stringifiedHeaders: { [headerName: string]: string } = {};
 
-        // don't send headers where values are undefined or null
+        // Only send present headers as strings
         Object.keys(headers).forEach(key => {
-            if (headers[key] == null) {
-                delete headers[key];
+            const headerValue = headers[key];
+            if (headerValue != null) {
+                stringifiedHeaders[key] = headerValue.toString();
             }
         });
 
         const fetchRequestInit: RequestInit = {
             credentials: "same-origin",
-            headers,
+            headers: stringifiedHeaders,
             method,
         };
 

--- a/src/httpApiBridge/httpApiBridge.ts
+++ b/src/httpApiBridge/httpApiBridge.ts
@@ -26,7 +26,7 @@ export interface IHttpEndpointOptions {
     endpointName?: string;
 
     /** HTTP headers. */
-    headers?: { [header: string]: string };
+    headers?: { [header: string]: string | number | boolean | undefined | null };
 
     /** HTTP method. */
     method: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,7 +1760,7 @@ istanbul-api@^1.1.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
@@ -3280,7 +3280,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2", statuses@~1.4.0:
+"statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
@@ -3790,3 +3790,4 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Typings did not allow any non-string header params.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
We conform to the conjure spec and allow all primitives (currently represented as string, number, boolean) as header parameters

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
