### PR TITLE
[improvement] make user agent optional

### DIFF
--- a/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
+++ b/src/httpApiBridge/fetchBridge/fetchBridgeImpl.ts
@@ -37,11 +37,6 @@ export interface IUserAgent {
     productVersion: string;
 }
 
-function formatUserAgent(userAgent: IUserAgent): string {
-    const { productName, productVersion } = userAgent;
-    return `${productName}/${productVersion}`;
-}
-
 export interface IFetchBridgeParams {
     baseUrl: string;
     /**
@@ -58,8 +53,8 @@ export class FetchBridgeImpl implements IHttpApiBridge {
 
     private readonly baseUrl: string;
     private readonly token: string | undefined;
-    private readonly fetch: FetchFunction | undefined;
-    private readonly userAgent: IUserAgent;
+    private readonly fetch?: FetchFunction;
+    private readonly userAgent?: IUserAgent;
 
     constructor(params: IFetchBridgeParams) {
         this.baseUrl = params.baseUrl;
@@ -71,7 +66,10 @@ export class FetchBridgeImpl implements IHttpApiBridge {
     public async callEndpoint<T>(params: IHttpEndpointOptions): Promise<T> {
         const url = `${this.baseUrl}/${this.buildPath(params)}${this.buildQueryString(params)}`;
         const { data, headers = {}, method, requestMediaType, responseMediaType } = params;
-        headers["Fetch-User-Agent"] = formatUserAgent(this.userAgent);
+
+        if (this.userAgent != null) {
+            headers["Fetch-User-Agent"] = this.formatUserAgent(this.userAgent);
+        }
 
         // don't send headers where values are undefined or null
         Object.keys(headers).forEach(key => {
@@ -204,5 +202,10 @@ export class FetchBridgeImpl implements IHttpApiBridge {
             input = input.slice(1);
         }
         return input;
+    }
+
+    private formatUserAgent(userAgent: IUserAgent): string {
+        const { productName, productVersion } = userAgent;
+        return `${productName}/${productVersion}`;
     }
 }


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
User-Agent was a required field to set on the bridge

## After this PR
<!-- Describe at a high-level why this approach is better. -->
User-Agent is optional. It didn't make sense outside of a palantir context. We can enforce through linting internally instead

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
