### PR TITLE
Support boolean request body

### DIFF
--- a/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -168,6 +168,28 @@ describe("FetchBridgeImpl", () => {
         await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
     });
 
+    it("makes POST request with boolean data", async () => {
+        const request: IHttpEndpointOptions = {
+            data: false,
+            endpointName: "a",
+            endpointPath: "a/{var}/b",
+            method: "POST",
+            pathArguments: ["val"],
+            queryArguments: {},
+            requestMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_JSON,
+        };
+        const expectedUrl = `${baseUrl}/a/val/b`;
+        const expectedFetchRequest = createFetchRequest({
+            data: false,
+            method: "POST",
+            responseMediaType: request.responseMediaType,
+        });
+        const expectedFetchResponse = createFetchResponse("false", 200);
+        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
+        await expect(bridge.callEndpoint(request)).resolves.toEqual(false);
+    });
+
     it("makes POST request with form data without setting 'Content-Type'", async () => {
         const fakeBinaryData = "dGVzdA==";
         const request: IHttpEndpointOptions = {

--- a/src/fetchBridge/fetchBridge.ts
+++ b/src/fetchBridge/fetchBridge.ts
@@ -93,7 +93,7 @@ export class FetchBridge implements IHttpApiBridge {
         if (this.token !== undefined) {
             fetchRequestInit.headers = { ...fetchRequestInit.headers, Authorization: `Bearer ${this.token}` };
         }
-        if (data) {
+        if (data != null) {
             fetchRequestInit.body = this.handleBody(params);
             if (requestMediaType != null && requestMediaType !== MediaType.MULTIPART_FORM_DATA) {
                 // don't include for form data because we need the browser to fill in the form boundary


### PR DESCRIPTION
Closes #21 
## Before this PR
We checked whether the provided data was false-y when determining whether to specify the body of the request

## After this PR
We explicitly check whether provided data is null or undefined
