### PR TITLE
[fix] Always add content type to requests

### DIFF
--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -95,6 +95,7 @@ export class FetchBridge implements IHttpApiBridge {
         }
 
         if (requestMediaType != null && requestMediaType !== MediaType.MULTIPART_FORM_DATA) {
+            // don't include for form data because we need the browser to fill in the form boundary
             (fetchRequestInit.headers as any)["Content-Type"] = requestMediaType;
         }
         if (responseMediaType != null) {

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -93,18 +93,18 @@ export class FetchBridge implements IHttpApiBridge {
         if (this.token !== undefined) {
             fetchRequestInit.headers = { ...fetchRequestInit.headers, Authorization: `Bearer ${this.token}` };
         }
-        if (data != null) {
-            fetchRequestInit.body = this.handleBody(params);
-            if (requestMediaType != null && requestMediaType !== MediaType.MULTIPART_FORM_DATA) {
-                // don't include for form data because we need the browser to fill in the form boundary
-                (fetchRequestInit.headers as any)["Content-Type"] = requestMediaType;
-            }
-        }
 
-        if (responseMediaType) {
+        if (requestMediaType != null && requestMediaType !== MediaType.MULTIPART_FORM_DATA) {
+            (fetchRequestInit.headers as any)["Content-Type"] = requestMediaType;
+        }
+        if (responseMediaType != null) {
             // If an endpoint can return multiple content types, make sure it returns the type that we're expecting
             // instead of the default `*/*
             (fetchRequestInit.headers as any)[FetchBridge.ACCEPT_HEADER] = responseMediaType;
+        }
+
+        if (data != null) {
+            fetchRequestInit.body = this.handleBody(params);
         }
 
         const fetchFunction = this.fetch || fetch;


### PR DESCRIPTION
## Before this PR
We would omit `content-type` headers if the body of the message was null 

## After this PR
We correctly conform to the [spec](https://github.com/palantir/conjure/blob/develop/docs/spec/wire.md#http-requests), always appending the content type regardless of the body