### PR TITLE
[improvement] support supplier of bearertokens

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -274,6 +274,27 @@ describe("FetchBridgeImpl", () => {
         await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
     });
 
+    it("passes dynamic tokens", async () => {
+        const tokenProvider: () => string = jest.fn().mockReturnValueOnce(token);
+        bridge = new FetchBridge({ baseUrl, token: tokenProvider, fetch: undefined, userAgent });
+
+        const request: IHttpEndpointOptions = {
+            endpointName: "a",
+            endpointPath: "a/",
+            method: "GET",
+            pathArguments: [],
+            queryArguments: {},
+        };
+        const expectedUrl = `${baseUrl}/a/`;
+        const expectedFetchRequest = createFetchRequest({
+            method: "GET",
+            responseMediaType: request.responseMediaType,
+        });
+        const expectedFetchResponse = createFetchResponse(undefined, 204);
+        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
+        await expect(bridge.callEndpoint(request)).resolves.toBeUndefined();
+    });
+
     it("passes headers", async () => {
         const request: IHttpEndpointOptions = {
             endpointName: "a",

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -51,7 +51,7 @@ export interface IFetchBridgeParams {
      * This will be logged in receiving service's request logs as params.User-Agent
      */
     userAgent: IUserAgent;
-    token?: string | Supplier<string | undefined>;
+    token?: string | Supplier<string>;
     fetch?: FetchFunction;
 }
 


### PR DESCRIPTION
## Before this PR
A single token would be used for the lifetime of the client

## After this PR
==COMMIT_MSG==
Consumers can provide a token supplier which allows the token to be changed during run time
==COMMIT_MSG==

## Possible downsides?
None that I'm aware of
