### PR TITLE
Add support for urlencoded form data

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -214,6 +214,33 @@ describe("FetchBridgeImpl", () => {
         await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
     });
 
+    it("makes POST request with url encoded form data", async () => {
+        const request: IHttpEndpointOptions = {
+            data: {
+                param1: "a",
+                param2: ["b", "c"],
+                "param=3": "ürl-êñçódèd",
+            },
+            endpointName: "a",
+            endpointPath: "a/{var}/b",
+            method: "POST",
+            pathArguments: ["val"],
+            queryArguments: {},
+            requestMediaType: MediaType.APPLICATION_X_WWW_FORM_URLENCODED,
+            responseMediaType: MediaType.APPLICATION_JSON,
+        };
+        const expectedUrl = `${baseUrl}/a/val/b`;
+        const expectedFetchRequest = createFetchRequest({
+            contentType: "application/x-www-form-urlencoded",
+            data: "param1=a&param2=b&param2=c&param%3D3=%C3%BCrl-%C3%AA%C3%B1%C3%A7%C3%B3d%C3%A8d",
+            method: "POST",
+            responseMediaType: request.responseMediaType,
+        });
+        const expectedFetchResponse = createFetchResponse(mockedResponseData, 200);
+        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
+        await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
+    });
+
     it("makes PUT request", async () => {
         const request: IHttpEndpointOptions = {
             data: mockedRequestData,

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -188,6 +188,22 @@ export class FetchBridge implements IHttpApiBridge {
         return query.length > 0 ? `?${query.join("&")}` : "";
     }
 
+    private buildFormString(parameters: IHttpEndpointOptions) {
+        const query: string[] = [];
+        for (const key of Object.keys(parameters.data)) {
+            const value = parameters.data[key];
+            if (value == null) {
+                continue;
+            }
+            if (value instanceof Array) {
+                value.forEach((v: any) => this.appendQueryParameter(query, key, v));
+            } else {
+                this.appendQueryParameter(query, key, value);
+            }
+        }
+        return query.join("&");
+    }
+
     private handleBody(parameters: IHttpEndpointOptions) {
         switch (parameters.requestMediaType) {
             case MediaType.APPLICATION_JSON:
@@ -195,6 +211,8 @@ export class FetchBridge implements IHttpApiBridge {
             case MediaType.APPLICATION_OCTET_STREAM:
             case MediaType.MULTIPART_FORM_DATA:
                 return parameters.data;
+            case MediaType.APPLICATION_X_WWW_FORM_URLENCODED:
+                return this.buildFormString(parameters);
             case MediaType.TEXT_PLAIN:
                 if (typeof parameters.data === "object") {
                     throw new Error("Invalid data: cannot send object as request media type text/plain");

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -71,7 +71,7 @@ export class FetchBridge implements IHttpApiBridge {
     }
 
     public async callEndpoint<T>(params: IHttpEndpointOptions): Promise<T> {
-        const query = this.buildQueryString(params);
+        const query = this.buildQueryString(params.queryArguments);
         const url = `${this.getBaseUrl()}/${this.buildPath(params)}${query.length > 0 ? `?${query}` : ""}`;
         const { data, headers = {}, method, requestMediaType, responseMediaType } = params;
         headers["Fetch-User-Agent"] = formatUserAgent(this.userAgent);
@@ -197,7 +197,7 @@ export class FetchBridge implements IHttpApiBridge {
             case MediaType.MULTIPART_FORM_DATA:
                 return parameters.data;
             case MediaType.APPLICATION_X_WWW_FORM_URLENCODED:
-                return this.buildQueryString(parameters);
+                return this.buildQueryString(parameters.data);
             case MediaType.TEXT_PLAIN:
                 if (typeof parameters.data === "object") {
                     throw new Error("Invalid data: cannot send object as request media type text/plain");

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -50,6 +50,7 @@ export interface IHttpEndpointOptions {
 export enum MediaType {
     APPLICATION_JSON = "application/json",
     APPLICATION_OCTET_STREAM = "application/octet-stream",
+    APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded",
     MULTIPART_FORM_DATA = "multipart/form-data",
     TEXT_PLAIN = "text/plain",
 }


### PR DESCRIPTION
We already have multipart form support, with this PR we also support urlencoded forms. Arrays are handled the same as in urls (i.e. multiple parameters of the same name with different values).