### PR TITLE
Add support for text/html

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -241,6 +241,30 @@ describe("FetchBridgeImpl", () => {
         await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
     });
 
+    it("makes POST request with html text data", async () => {
+        const fakeHtmlData = "<html>Hello World</html>";
+        const request: IHttpEndpointOptions = {
+            data: fakeHtmlData,
+            endpointName: "a",
+            endpointPath: "a/{var}/b",
+            method: "POST",
+            pathArguments: ["val"],
+            queryArguments: {},
+            requestMediaType: MediaType.TEXT_HTML,
+            responseMediaType: MediaType.APPLICATION_JSON,
+        };
+        const expectedUrl = `${baseUrl}/a/val/b`;
+        const expectedFetchRequest = createFetchRequest({
+            contentType: "text/html",
+            data: fakeHtmlData,
+            method: "POST",
+            responseMediaType: request.responseMediaType,
+        });
+        const expectedFetchResponse = createFetchResponse(mockedResponseData, 200);
+        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
+        await expect(bridge.callEndpoint(request)).resolves.toEqual(mockedResponseData);
+    });
+
     it("makes PUT request", async () => {
         const request: IHttpEndpointOptions = {
             data: mockedRequestData,

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -201,7 +201,9 @@ export class FetchBridge implements IHttpApiBridge {
             case MediaType.TEXT_HTML:
             case MediaType.TEXT_PLAIN:
                 if (typeof parameters.data === "object") {
-                    throw new Error(`Invalid data: cannot send object as request media type ${parameters.requestMediaType}`);
+                    throw new Error(
+                        `Invalid data: cannot send object as request media type ${parameters.requestMediaType}`,
+                    );
                 }
                 return parameters.data;
             default:

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -198,9 +198,10 @@ export class FetchBridge implements IHttpApiBridge {
                 return parameters.data;
             case MediaType.APPLICATION_X_WWW_FORM_URLENCODED:
                 return this.buildQueryString(parameters.data);
+            case MediaType.TEXT_HTML:
             case MediaType.TEXT_PLAIN:
                 if (typeof parameters.data === "object") {
-                    throw new Error("Invalid data: cannot send object as request media type text/plain");
+                    throw new Error(`Invalid data: cannot send object as request media type ${parameters.requestMediaType}`);
                 }
                 return parameters.data;
             default:

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -52,6 +52,7 @@ export enum MediaType {
     APPLICATION_OCTET_STREAM = "application/octet-stream",
     APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded",
     MULTIPART_FORM_DATA = "multipart/form-data",
+    TEXT_HTML = "text/html",
     TEXT_PLAIN = "text/plain",
 }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Not possible to specify "text/html" as media type for a request or response.

## After this PR
==COMMIT_MSG==
Support specifying "text/html" as media type.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

