### PR TITLE
Safer buildQueryString

### DIFF
--- a/changelog/@unreleased/pr-94.v2.yml
+++ b/changelog/@unreleased/pr-94.v2.yml
@@ -1,5 +1,5 @@
-type: break
-break:
-  description: Improve typing to IHttpEndpointOptions.queryArguments
+type: fix
+fix:
+  description: Check that queryArguments is non-null before iterating over keys
   links:
     - https://github.com/palantir/conjure-typescript-runtime/pull/94

--- a/changelog/@unreleased/pr-94.v2.yml
+++ b/changelog/@unreleased/pr-94.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Check that queryArguments is non-null before iterating over keys
+  links:
+    - https://github.com/palantir/conjure-typescript-runtime/pull/94

--- a/changelog/@unreleased/pr-94.v2.yml
+++ b/changelog/@unreleased/pr-94.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
-  description: Check that queryArguments is non-null before iterating over keys
+type: break
+break:
+  description: Improve typing to IHttpEndpointOptions.queryArguments
   links:
     - https://github.com/palantir/conjure-typescript-runtime/pull/94

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -190,7 +190,11 @@ export class FetchBridge implements IHttpApiBridge {
         return path;
     }
 
-    private buildQueryString(data: { [key: string]: any }) {
+    private buildQueryString(data: any) {
+        if (data == null) {
+            return "";
+        }
+
         const query: string[] = [];
         for (const key of Object.keys(data)) {
             const value = data[key];

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -190,7 +190,7 @@ export class FetchBridge implements IHttpApiBridge {
         return path;
     }
 
-    private buildQueryString(data: any) {
+    private buildQueryString(data: { [key: string]: any }) {
         if (data == null) {
             return "";
         }

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -41,7 +41,7 @@ export interface IHttpEndpointOptions {
     pathArguments: any[];
 
     /** Key-value mappings to be appended to the request query string. */
-    queryArguments: { [key: string]: any };
+    queryArguments: any;
 
     /** Data to send in the body. */
     data?: any;

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -41,7 +41,7 @@ export interface IHttpEndpointOptions {
     pathArguments: any[];
 
     /** Key-value mappings to be appended to the request query string. */
-    queryArguments: any;
+    queryArguments: { [key: string]: any };
 
     /** Data to send in the body. */
     data?: any;


### PR DESCRIPTION
## Before this PR
`buildQueryString` assumed it would take an object, and then iterated through its keys. However, because in both of its uses it was being passed an `any`, it was not guaranteed that it is an object. This lead to conjure-client-factory passing `params.queryArguments = undefined`, which would cause an error.

## After this PR
==COMMIT_MSG==
Check that queryArguments is non-null before iterating over keys
==COMMIT_MSG==