### PR TITLE
Do not rely on the ConjureError constructor name in isConjureError

### DIFF
--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -50,5 +50,6 @@ export class ConjureError<E> {
 }
 
 export function isConjureError(error: any): error is ConjureError<never> {
-    return error instanceof ConjureError;
+    const conjureErrorTypes = Object.keys(ConjureErrorType).map(key => (ConjureErrorType[key as keyof typeof ConjureErrorType]));   
+    return error != null && conjureErrorTypes.indexOf(error.type) !== -1 && (error.status == null || typeof error.status === "number");
 }

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -50,6 +50,12 @@ export class ConjureError<E> {
 }
 
 export function isConjureError(error: any): error is ConjureError<never> {
-    const conjureErrorTypes = Object.keys(ConjureErrorType).map(key => (ConjureErrorType[key as keyof typeof ConjureErrorType]));   
-    return error != null && conjureErrorTypes.indexOf(error.type) !== -1 && (error.status == null || typeof error.status === "number");
+    const conjureErrorTypes = Object.keys(ConjureErrorType).map(
+        key => (ConjureErrorType[key as keyof typeof ConjureErrorType]),
+    );
+    return (
+        error != null &&
+        conjureErrorTypes.indexOf(error.type) !== -1 &&
+        (error.status == null || typeof error.status === "number")
+    );
 }

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -51,7 +51,7 @@ export class ConjureError<E> {
 
 export function isConjureError(error: any): error is ConjureError<never> {
     const conjureErrorTypes = Object.keys(ConjureErrorType).map(
-        key => (ConjureErrorType[key as keyof typeof ConjureErrorType]),
+        key => ConjureErrorType[key as keyof typeof ConjureErrorType],
     );
     return (
         error != null &&

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -50,8 +50,5 @@ export class ConjureError<E> {
 }
 
 export function isConjureError(error: any): error is ConjureError<never> {
-    return (
-        error instanceof ConjureError ||
-        (error.__proto__ && error.__proto__.constructor && error.__proto__.constructor.name === ConjureError.name)
-    );
+    return error instanceof ConjureError;
 }


### PR DESCRIPTION
## Before this PR
The constructor names can be minified in production code.

If conjure-client if compiled in two different webpack bundles, the resulting minified constructor names can be different.

This results in `isConjureError` returning `false`, when in fact it should return `true`.

## After this PR
==COMMIT_MSG==
Do not rely on the ConjureError constructor name in isConjureError
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

