### PR TITLE
Fix handling of RetryAfter header

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/retryingFetchTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/retryingFetchTests.ts
@@ -100,7 +100,7 @@ describe("RetryingFetch", () => {
         const expectedFetchRequest = createFetchRequest("POST");
         const expectedFetchResponse = createFetchResponse(undefined, 429);
         if (expectedFetchResponse.headers instanceof Headers) {
-            expectedFetchResponse.headers.append("Retry-After", "123");
+            expectedFetchResponse.headers.append("Retry-After", "2");
         }
 
         const delegateFetch = jest.fn((_, __) => {
@@ -117,7 +117,7 @@ describe("RetryingFetch", () => {
         window.setTimeout = mockedSetTimeout;
 
         await retryingFetch.fetch(expectedUrl, expectedFetchRequest);
-        expect(mockedSetTimeout.mock.calls[0][1]).toEqual(123);
+        expect(mockedSetTimeout.mock.calls[0][1]).toEqual(2000);
 
         // restore
         window.setTimeout = originalSetTimeout;

--- a/packages/conjure-client/src/fetchBridge/retryingFetch.ts
+++ b/packages/conjure-client/src/fetchBridge/retryingFetch.ts
@@ -62,22 +62,23 @@ export class RetryingFetch {
         });
     }
 
-    private getRetryAfterHeaderValue(response: IFetchResponse): number | undefined {
+    private getRetryAfterHeaderValueInMilliseconds(response: IFetchResponse): number | undefined {
         const retryAfterHeader = response.headers.get("Retry-After");
         if (retryAfterHeader == null) {
             return undefined;
         }
 
-        const retryAfter = parseInt(retryAfterHeader, 10);
-        if (isNaN(retryAfter)) {
+        const retryAfterInSeconds = parseInt(retryAfterHeader, 10);
+        if (isNaN(retryAfterInSeconds)) {
             return undefined;
         }
 
-        if (retryAfter < 0 || retryAfter > MAX_RETRY_AFTER_MS) {
+        const retryAfterInMilliseconds = retryAfterInSeconds * 1000;
+        if (retryAfterInMilliseconds < 0 || retryAfterInMilliseconds > MAX_RETRY_AFTER_MS) {
             return undefined;
         }
 
-        return retryAfter;
+        return retryAfterInMilliseconds;
     }
 
     private getRetryAfter(response: IFetchResponse, attempt: number): number | undefined {
@@ -87,7 +88,7 @@ export class RetryingFetch {
                 return undefined;
             }
 
-            const retryAfterFromHeader = this.getRetryAfterHeaderValue(response);
+            const retryAfterFromHeader = this.getRetryAfterHeaderValueInMilliseconds(response);
             if (retryAfterFromHeader !== undefined) {
                 return retryAfterFromHeader;
             } else {


### PR DESCRIPTION
## Before this PR
RetryAfter header on 429 responses is incorrectly interpreted in milliseconds.

## After this PR
Fixes #103 
==COMMIT_MSG==
Respect RetryAfter header on 429 responses.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

