### PR TITLE
Reduce code size of conjure APIs

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,3 +1,4 @@
-# Excavator auto-updates this file. Please contribute improvements to the central template.
-
-# This file is intentionally empty. The file's existence enables changelog-app and is empty to use the default configuration.
+repo-type:
+  type: default
+  default:
+    changelogDir: changelog

--- a/changelog/@unreleased/pr-105.v2.yml
+++ b/changelog/@unreleased/pr-105.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add call method to HTTPBridge which takes a list of parameters instead of a request object to reduce the size of generated code
+  links:
+   - https://github.com/palantir/conjure-typescript-runtime/pull/105

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -16,7 +16,7 @@
  */
 
 import { ConjureError, ConjureErrorType } from "../errors";
-import { IHttpApiBridge, IHttpEndpointOptions, IMinifiedHttpEndpointOptions, MediaType } from "../httpApiBridge";
+import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../httpApiBridge";
 import { blobToReadableStream } from "./blobReadableStreamAdapter";
 
 export interface IFetchBody {
@@ -72,18 +72,31 @@ export class FetchBridge implements IHttpApiBridge {
         this.userAgent = params.userAgent;
     }
 
-    public call<T>(params: IMinifiedHttpEndpointOptions): Promise<T> {
+    public call<T>(
+        serviceName: string,
+        endpointPath: string,
+        endpointName: string,
+        method: string,
+        data?: any,
+        headers?: { [p: string]: string | number | boolean | undefined | null },
+        queryArguments?: { [p: string]: any },
+        pathArguments?: any[],
+        requestMediaType?: string,
+        responseMediaType?: string,
+    ): Promise<T> {
         return this.callEndpoint({
-            serviceName: params.sn,
-            endpointPath: params.ep,
-            endpointName: params.en,
-            headers: params.h == null ? {} : params.h,
-            method: params.m,
-            requestMediaType: params.reqmt == null ? MediaType.APPLICATION_JSON : this.getMediaType(params.reqmt),
-            responseMediaType: params.respmt == null ? MediaType.APPLICATION_JSON : this.getMediaType(params.respmt),
-            pathArguments: params.pa == null ? [] : params.pa,
-            queryArguments: params.qa == null ? {} : params.qa,
-            data: params.d,
+            serviceName,
+            endpointPath,
+            endpointName,
+            method,
+            data,
+            headers: headers == null ? {} : headers,
+            requestMediaType:
+                requestMediaType == null ? MediaType.APPLICATION_JSON : this.getMediaType(requestMediaType),
+            responseMediaType:
+                responseMediaType == null ? MediaType.APPLICATION_JSON : this.getMediaType(responseMediaType),
+            queryArguments: queryArguments == null ? {} : queryArguments,
+            pathArguments: pathArguments == null ? [] : pathArguments,
             binaryAsStream: true,
         });
     }

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -50,6 +50,38 @@ export interface IHttpEndpointOptions {
     binaryAsStream?: boolean;
 }
 
+export interface IMinifiedHttpEndpointOptions {
+    /** Conjure service name. Doesn't affect the network request. */
+    sn: string;
+
+    /** Path to make a request to, e.g. "/foo/{param1}/bar". */
+    ep: string;
+
+    /** Conjure endpoint name. Doesn't affect the network request. */
+    en: string;
+
+    /** HTTP headers. */
+    h?: { [header: string]: string | number | boolean | undefined | null };
+
+    /** HTTP method. */
+    m: string;
+
+    /** MIME type of the outgoing request, if absent defaults to "application/json" */
+    reqmt?: string;
+
+    /** MIME type of the expected server response, if absent defaults to "application/json" */
+    respmt?: string;
+
+    /** Values to be interpolated into the endpointPath. */
+    pa?: any[];
+
+    /** Key-value mappings to be appended to the request query string. */
+    qa: { [paramName: string]: any };
+
+    /** Data to send in the body. */
+    d?: any;
+}
+
 export enum MediaType {
     APPLICATION_JSON = "application/json",
     APPLICATION_OCTET_STREAM = "application/octet-stream",
@@ -60,4 +92,9 @@ export enum MediaType {
 
 export interface IHttpApiBridge {
     callEndpoint<T>(parameters: IHttpEndpointOptions): Promise<T>;
+
+    /**
+     * Identical to callEndpoint but the field names are shortened to reduce code size
+     */
+    call<T>(params: IMinifiedHttpEndpointOptions): Promise<T>;
 }

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -50,38 +50,6 @@ export interface IHttpEndpointOptions {
     binaryAsStream?: boolean;
 }
 
-export interface IMinifiedHttpEndpointOptions {
-    /** Conjure service name. Doesn't affect the network request. */
-    sn: string;
-
-    /** Path to make a request to, e.g. "/foo/{param1}/bar". */
-    ep: string;
-
-    /** Conjure endpoint name. Doesn't affect the network request. */
-    en: string;
-
-    /** HTTP headers. */
-    h?: { [header: string]: string | number | boolean | undefined | null };
-
-    /** HTTP method. */
-    m: string;
-
-    /** MIME type of the outgoing request, if absent defaults to "application/json" */
-    reqmt?: string;
-
-    /** MIME type of the expected server response, if absent defaults to "application/json" */
-    respmt?: string;
-
-    /** Values to be interpolated into the endpointPath. */
-    pa?: any[];
-
-    /** Key-value mappings to be appended to the request query string. */
-    qa: { [paramName: string]: any };
-
-    /** Data to send in the body. */
-    d?: any;
-}
-
 export enum MediaType {
     APPLICATION_JSON = "application/json",
     APPLICATION_OCTET_STREAM = "application/octet-stream",
@@ -94,7 +62,29 @@ export interface IHttpApiBridge {
     callEndpoint<T>(parameters: IHttpEndpointOptions): Promise<T>;
 
     /**
-     * Identical to callEndpoint but the field names are shortened to reduce code size
+     * Identical to callEndpoint replacing a request object with individual parameters to reduce the total code size
+     * because of the field name overhead.
      */
-    call<T>(params: IMinifiedHttpEndpointOptions): Promise<T>;
+    call<T>(
+        /** Conjure service name. Doesn't affect the network request. */
+        serviceName: string,
+        /** Path to make a request to, e.g. "/foo/{param1}/bar". */
+        endpointPath: string,
+        /** Conjure endpoint name. Doesn't affect the network request. */
+        endpointName: string,
+        /** HTTP method. */
+        method: string,
+        /** Data to send in the body. */
+        data?: any,
+        /** HTTP headers. */
+        headers?: { [header: string]: string | number | boolean | undefined | null },
+        /** Key-value mappings to be appended to the request query string. */
+        queryParams?: { [paramName: string]: any },
+        /** Values to be interpolated into the endpointPath. */
+        pathArguments?: any[],
+        /** MIME type of the outgoing request, if absent defaults to "application/json" */
+        requestMediaType?: string,
+        /** MIME type of the expected server response, if absent defaults to "application/json" */
+        responseMediaType?: string,
+    ): Promise<T>;
 }

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -68,10 +68,10 @@ export interface IHttpApiBridge {
     call<T>(
         /** Conjure service name. Doesn't affect the network request. */
         serviceName: string,
-        /** Path to make a request to, e.g. "/foo/{param1}/bar". */
-        endpointPath: string,
         /** Conjure endpoint name. Doesn't affect the network request. */
         endpointName: string,
+        /** Path to make a request to, e.g. "/foo/{param1}/bar". */
+        endpointPath: string,
         /** HTTP method. */
         method: string,
         /** Data to send in the body. */

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -70,10 +70,10 @@ export interface IHttpApiBridge {
         serviceName: string,
         /** Conjure endpoint name. Doesn't affect the network request. */
         endpointName: string,
-        /** Path to make a request to, e.g. "/foo/{param1}/bar". */
-        endpointPath: string,
         /** HTTP method. */
         method: string,
+        /** Path to make a request to, e.g. "/foo/{param1}/bar". */
+        endpointPath: string,
         /** Data to send in the body. */
         data?: any,
         /** HTTP headers. */


### PR DESCRIPTION
## Before this PR
We required users to make requests over the HTTP bridge using `callEndpoint` which took a single request object as a parameter. While clean from a code perspective, this resulted in a larger than necessary code size since each endpoint needed to have the full human readable field names.

## After this PR
==COMMIT_MSG==
Add `call` method to `HTTPBridge` which takes a list of parameters instead of a request object to reduce the size of generated code
==COMMIT_MSG==

## Possible downsides?
Its another way of doing the same thing, so people might get confused. Might also lead to some issue in places that re-implement the conjure bridge API 

