### PR TITLE
Improve `Fetch-User-Agent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ coverage
 .idea
 *.iml
 
+generated
+
 build

--- a/packages/conjure-client/package.json
+++ b/packages/conjure-client/package.json
@@ -9,6 +9,7 @@
     "build": "npm-run-all clean lint compile test",
     "circle-publish": "./scripts/circle-publish-npm",
     "clean": "rm -rf lib/*",
+    "precompile": "./scripts/generate-library-version.sh",
     "compile": "tsc -p ./src",
     "downloadConjureTypeScript": "./scripts/download-conjure-typescript.sh",
     "downloadTestServer": "./scripts/download-test-server.sh",

--- a/packages/conjure-client/scripts/generate-library-version.sh
+++ b/packages/conjure-client/scripts/generate-library-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+mkdir -p src/generated
+echo "export const IMPLEMENTATION_VERSION = '"${CIRCLE_TAG:-"0.0.0"}"';" > src/generated/index.ts
+

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
@@ -20,7 +20,8 @@ import * as http from "http";
 import * as nodeFetch from "node-fetch";
 import { TextDecoder, TextEncoder } from "util";
 import { IHttpApiBridge } from "../../httpApiBridge";
-import { FetchBridge, IUserAgent } from "../fetchBridge";
+import { IUserAgent } from "../../userAgent";
+import { FetchBridge } from "../fetchBridge";
 import { ConjureService } from "./conjureService";
 import { nodeFetchStreamAdapter } from "./nodeFetchStreamAdapter";
 

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -18,7 +18,8 @@
 import * as fetchMock from "fetch-mock";
 import { ConjureError, ConjureErrorType } from "../../errors";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../../httpApiBridge";
-import { FetchBridge, IUserAgent } from "../fetchBridge";
+import { IUserAgent } from "../../userAgent";
+import { FetchBridge } from "../fetchBridge";
 
 const baseUrl = "https://host.domain/path";
 const token = "TOKEN";
@@ -482,7 +483,7 @@ function createFetchRequest(opts: ICreateFetchRequestOpts): RequestInit {
         headers: {
             ...headers,
             Authorization: `Bearer ${token}`,
-            "Fetch-User-Agent": "foo/1.2.3",
+            "Fetch-User-Agent": "foo/1.2.3 conjure-client/0.0.0",
         },
         method,
     };

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -484,7 +484,7 @@ function createFetchRequest(opts: ICreateFetchRequestOpts): RequestInit {
         headers: {
             ...headers,
             Authorization: `Bearer ${token}`,
-            "Fetch-User-Agent": `foo/1.2.3 conjure-client/${IMPLEMENTATION_VERSION}`,
+            "Fetch-User-Agent": `foo/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`,
         },
         method,
     };

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -20,6 +20,7 @@ import { ConjureError, ConjureErrorType } from "../../errors";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../../httpApiBridge";
 import { IUserAgent } from "../../userAgent";
 import { FetchBridge } from "../fetchBridge";
+import { IMPLEMENTATION_VERSION } from "../../generated";
 
 const baseUrl = "https://host.domain/path";
 const token = "TOKEN";
@@ -483,7 +484,7 @@ function createFetchRequest(opts: ICreateFetchRequestOpts): RequestInit {
         headers: {
             ...headers,
             Authorization: `Bearer ${token}`,
-            "Fetch-User-Agent": "foo/1.2.3 conjure-client/0.0.0",
+            "Fetch-User-Agent": `foo/1.2.3 conjure-client/${IMPLEMENTATION_VERSION}`,
         },
         method,
     };

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -17,10 +17,10 @@
 
 import * as fetchMock from "fetch-mock";
 import { ConjureError, ConjureErrorType } from "../../errors";
+import { IMPLEMENTATION_VERSION } from "../../generated";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../../httpApiBridge";
 import { IUserAgent } from "../../userAgent";
 import { FetchBridge } from "../fetchBridge";
-import { IMPLEMENTATION_VERSION } from "../../generated";
 
 const baseUrl = "https://host.domain/path";
 const token = "TOKEN";

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -62,7 +62,7 @@ export class FetchBridge implements IHttpApiBridge {
         this.getToken = typeof params.token === "function" ? params.token : () => params.token as string | undefined;
         this.fetch = params.fetch;
         this.userAgent = new UserAgent(params.userAgent, [
-            { productName: "conjure-client", productVersion: IMPLEMENTATION_VERSION },
+            { productName: "conjure-typescript-runtime", productVersion: IMPLEMENTATION_VERSION },
         ]);
     }
 

--- a/packages/conjure-client/src/userAgent.ts
+++ b/packages/conjure-client/src/userAgent.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2020 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface IUserAgent {
+    productName: string;
+    productVersion: string;
+}
+
+/**
+ * @internal
+ */
+export class UserAgent {
+    private readonly stringValue: string;
+
+    constructor(private readonly primary: IUserAgent, private readonly informational: IUserAgent[]) {
+        this.stringValue = [this.primary, ...this.informational].map(formatUserAgent).join(" ");
+    }
+
+    public addAgent(agent: IUserAgent): UserAgent {
+        return new UserAgent(this.primary, [...this.informational, agent]);
+    }
+
+    public toString() {
+        return this.stringValue;
+    }
+}
+
+function formatUserAgent(userAgent: IUserAgent): string {
+    const { productName, productVersion } = userAgent;
+    return `${productName}/${productVersion}`;
+}

--- a/packages/conjure-client/tslint.json
+++ b/packages/conjure-client/tslint.json
@@ -8,5 +8,8 @@
       "Copyright \\d{4} Palantir Technologies, Inc."
     ],
     "object-literal-sort-keys": false
+  },
+  "linterOptions": {
+    "exclude": ["src/generated/*"]
   }
 }


### PR DESCRIPTION
## Before this PR
We would plumb the exact user agent that was provided to us as the `Fetch-User-Agent` header on each request. This worked reasonably well, but made it difficult to disambiguate requests made through the ts conjure runtime from other requests.

This became particularly annoying when attempting to do an analysis on the source of deprecated requests. 

## After this PR
==COMMIT_MSG==
Augment `Fetch-User-Agent` with the version the version of conjure-client used
==COMMIT_MSG==

## Possible downsides?
N/A

