### PR TITLE
Fix accidental break

### DIFF
--- a/packages/conjure-client/src/index.ts
+++ b/packages/conjure-client/src/index.ts
@@ -19,3 +19,4 @@ export { FetchBridge as DefaultHttpApiBridge } from "./fetchBridge";
 export * from "./fetchBridge";
 export * from "./httpApiBridge";
 export * from "./errors";
+export { IUserAgent } from "./userAgent";


### PR DESCRIPTION
## Before this PR
#106 accidentally made `IUserAgent` private, breaking downstream packages

## After this PR
==COMMIT_MSG==
Fix break introduced in 2.2.0
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

