### PR TITLE
Fix ordering of parameters

### DIFF
--- a/changelog/@unreleased/pr-109.v2.yml
+++ b/changelog/@unreleased/pr-109.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix ordering of parameters in new `call` method on `FetchBridge`
+  links:
+  - https://github.com/palantir/conjure-typescript-runtime/pull/109

--- a/packages/conjure-client/src/fetchBridge/__tests__/conjureService.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/conjureService.ts
@@ -48,6 +48,10 @@ export class ConjureService {
         });
     }
 
+    public bodyCompact(data: any): Promise<string> {
+        return this.bridge.call("ConjureService", "bodyCompact", "POST", "/body", data);
+    }
+
     public binary(): Promise<ReadableStream<Uint8Array>> {
         return this.bridge.callEndpoint<ReadableStream<Uint8Array>>({
             endpointName: "binary",

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
@@ -98,6 +98,24 @@ describe("FetchBridgeImplServer", () => {
             .catch(fail);
     });
 
+    it("compact method should receive JSON stringified payloads", done => {
+        const payload = { dataset: "foo", count: 1 };
+
+        app.all("/*", (_req, res) => {
+            res.status(200)
+                .type("application/json")
+                .send(JSON.stringify(payload));
+        });
+
+        new ConjureService(bridge)
+            .bodyCompact(payload)
+            .then(s => {
+                expect(s).toEqual(payload);
+                done();
+            })
+            .catch(fail);
+    });
+
     it("should stream binary responses", testDone => {
         const response = { dataset: "foo", count: 1 };
 

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -68,9 +68,9 @@ export class FetchBridge implements IHttpApiBridge {
 
     public call<T>(
         serviceName: string,
-        endpointPath: string,
         endpointName: string,
         method: string,
+        endpointPath: string,
         data?: any,
         headers?: { [p: string]: string | number | boolean | undefined | null },
         queryArguments?: { [p: string]: any },
@@ -80,9 +80,9 @@ export class FetchBridge implements IHttpApiBridge {
     ): Promise<T> {
         return this.callEndpoint({
             serviceName,
-            endpointPath,
             endpointName,
             method,
+            endpointPath,
             data,
             headers: headers == null ? {} : headers,
             requestMediaType:

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -79,7 +79,7 @@ export interface IHttpApiBridge {
         /** HTTP headers. */
         headers?: { [header: string]: string | number | boolean | undefined | null },
         /** Key-value mappings to be appended to the request query string. */
-        queryParams?: { [paramName: string]: any },
+        queryArguments?: { [paramName: string]: any },
         /** Values to be interpolated into the endpointPath. */
         pathArguments?: any[],
         /** MIME type of the outgoing request, if absent defaults to "application/json" */


### PR DESCRIPTION
## Before this PR
There was an inconsistency in the ordering of parameter names between the `IHttpBridge` interface and `FetchBridge` implementation that ended up causing illegal requests to be made.

Not surprising when you have a with 4 consecutive `string` parameters, but thats the price of perf. Unfortunately even if we did have the verifier set up it wouldn't have caught this.

## After this PR
==COMMIT_MSG==
Fix ordering of parameters in new `call` method on `FetchBridge`
==COMMIT_MSG==

## Possible downsides?
N/A

