### PR TITLE
Update binary links to Maven

### DIFF
--- a/packages/conjure-client/scripts/download-conjure-typescript.sh
+++ b/packages/conjure-client/scripts/download-conjure-typescript.sh
@@ -8,7 +8,7 @@ DOWNLOAD_OUTPUT="build/downloads/conjure-typescript.tgz"
 
 if [ ! -d "build/conjure-typescript/${ARTIFACT_NAME}" ]; then
     mkdir -p build/downloads
-    curl -L "https://palantir.bintray.com/releases/com/palantir/conjure/typescript/conjure-typescript/${VERSION}/${ARTIFACT_NAME}.tgz" -o "$DOWNLOAD_OUTPUT"
+    curl -L "https://repo1.maven.org/maven2/com/palantir/conjure/typescript/conjure-typescript/${VERSION}/${ARTIFACT_NAME}.tgz" -o "$DOWNLOAD_OUTPUT"
 
     tar xf "$DOWNLOAD_OUTPUT" -C build
     mv "build/$ARTIFACT_NAME" build/conjure-typescript

--- a/packages/conjure-client/scripts/download-test-server.sh
+++ b/packages/conjure-client/scripts/download-test-server.sh
@@ -26,12 +26,12 @@ function download() {
 
 DOWNLOAD_OUTPUT="$RESOURCES_DIR/${API}.conjure.json"
 ARTIFACT_NAME="${API}-${VERSION}.conjure.json"
-out=$(download "https://palantir.bintray.com/releases/com/palantir/conjure/verification/${API}/${VERSION}/${ARTIFACT_NAME}")
+out=$(download "https://repo1.maven.org/maven2/com/palantir/conjure/verification/${API}/${VERSION}/${ARTIFACT_NAME}")
 cp -f "$out" "$DOWNLOAD_OUTPUT"
 
 DOWNLOAD_OUTPUT="$RESOURCES_DIR/${TEST_CASES}.json"
 ARTIFACT_NAME="${TEST_CASES}-${VERSION}.json"
-out=$(download "https://palantir.bintray.com/releases/com/palantir/conjure/verification/${TEST_CASES}/${VERSION}/${ARTIFACT_NAME}")
+out=$(download "https://repo1.maven.org/maven2/com/palantir/conjure/verification/${TEST_CASES}/${VERSION}/${ARTIFACT_NAME}")
 cp -f "$out" "$DOWNLOAD_OUTPUT"
 
 
@@ -42,6 +42,6 @@ case $(uname -s) in
 esac
 
 ARTIFACT_NAME="${SERVER}-${VERSION}-${TARGET}.tgz"
-out=$(download "https://palantir.bintray.com/releases/com/palantir/conjure/verification/${SERVER}/${VERSION}/${ARTIFACT_NAME}")
+out=$(download "https://repo1.maven.org/maven2/com/palantir/conjure/verification/${SERVER}/${VERSION}/${ARTIFACT_NAME}")
 tar xf "$out" -C "$DOWNLOADS_DIR/bin"
 chmod +x "$DOWNLOADS_DIR/bin/conjure-verification-server"

--- a/versions.props
+++ b/versions.props
@@ -1,3 +1,3 @@
 # User versions.props so that excavator can automatically keep our version up to date
-com.palantir.conjure.verification:* = 0.18.5
-com.palantir.conjure.typescript:conjure-typescript = 3.9.3
+com.palantir.conjure.verification:* = 0.19.0
+com.palantir.conjure.typescript:conjure-typescript = 5.1.0


### PR DESCRIPTION
## Before this PR
Binary downloads point to the old Bintray location.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Download binaries from maven-central. See https://github.com/palantir/conjure-typescript/pull/168 for details.
==COMMIT_MSG==

## Possible downsides?
None.

