### PR TITLE
Switch to LTS node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.1-browsers
+      - image: circleci/openjdk:11-node-browsers
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Before this PR
Using EOL Node 8 on CI.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use LTS node on CI.
==COMMIT_MSG==

Note that we use JDK version of the image in anticipation of building this project fully with Gradle, see https://github.com/palantir/conjure-typescript/pull/168 for details.

## Possible downsides?
None.

