### PR TITLE
Add AbortSignal to HTTPApiBridge and fetchBridge

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/conjureService.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/conjureService.ts
@@ -34,6 +34,24 @@ export class ConjureService {
         });
     }
 
+    public abortedString(): Promise<string> {
+        const abortController = new AbortController();
+        const request = this.bridge.callEndpoint<string>({
+            data: undefined,
+            endpointName: "string",
+            endpointPath: "/string",
+            headers: {},
+            method: "GET",
+            pathArguments: [],
+            queryArguments: {},
+            requestMediaType: MediaType.APPLICATION_JSON,
+            responseMediaType: MediaType.APPLICATION_JSON,
+            signal: abortController.signal,
+        });
+        abortController.abort();
+        return request;
+    }
+
     public body(data: any): Promise<string> {
         return this.bridge.callEndpoint<string>({
             data,

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeServerTests.ts
@@ -80,6 +80,22 @@ describe("FetchBridgeImplServer", () => {
             .catch(fail);
     });
 
+    it("should abort requests once a provided AbortSignal has been enabled", done => {
+        app.all("/*", (_req, res) => {
+            res.status(200)
+                .type("application/json")
+                .send('"Hello, world!"');
+        });
+
+        new ConjureService(bridge)
+            .abortedString()
+            .then(fail)
+            .catch(e => {
+                expect(e.originalError.toString()).toContain("AbortError");
+                done();
+            });
+    });
+
     it("should receive JSON stringified payloads", done => {
         const payload = { dataset: "foo", count: 1 };
 

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -157,7 +157,7 @@ export class FetchBridge implements IHttpApiBridge {
     private makeFetchCall(params: IHttpEndpointOptions): Promise<IFetchResponse> {
         const query = this.buildQueryString(params.queryArguments);
         const url = `${this.getBaseUrl()}/${this.buildPath(params)}${query.length > 0 ? `?${query}` : ""}`;
-        const { data, headers = {}, method, requestMediaType, responseMediaType } = params;
+        const { data, headers = {}, method, requestMediaType, responseMediaType, signal } = params;
         const stringifiedHeaders: { [headerName: string]: string } = {
             "Fetch-User-Agent": this.userAgent.toString(),
         };
@@ -189,6 +189,10 @@ export class FetchBridge implements IHttpApiBridge {
             // If an endpoint can return multiple content types, make sure it returns the type that we're expecting
             // instead of the default `*/*
             (fetchRequestInit.headers as any)[FetchBridge.ACCEPT_HEADER] = responseMediaType;
+        }
+
+        if (signal != null) {
+            fetchRequestInit.signal = signal;
         }
 
         if (data != null) {

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -48,6 +48,9 @@ export interface IHttpEndpointOptions {
 
     /** return binary response as web stream */
     binaryAsStream?: boolean;
+
+    /** AbortSignal to allow the abortion of a fetch via an AbortController */
+    signal?: AbortSignal;
 }
 
 export enum MediaType {


### PR DESCRIPTION
## Before this PR
The fetch client enables users to abort a request if it is no longer required, this is especially useful if your request is for a large amount of data and also signals to the server that the request no longer needs to be fulfilled. The current conjure runtime implementation does not support a way of passing an AbortSignal to a request.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `callEndpoint` method now accepts an AbortSignal `signal` parameter, allowing requests to be aborted from the client.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
AbortController and AbortSignal are not supported by Internet Explorer, so would have to be polyfilled by those browsers in order to use this feature.
