### PR TITLE
allow the token supplier to be async

### DIFF
--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -401,7 +401,7 @@ describe("FetchBridgeImpl", () => {
             await bridge.callEndpoint(request);
             fail("Did not throw an error");
         } catch (error) {
-            expect(error.message).toBe("Unrecognized request media type " + unrecognizedType);
+            expect(error.originalError.message).toBe("Unrecognized request media type " + unrecognizedType);
         }
     });
 

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -332,6 +332,27 @@ describe("FetchBridgeImpl", () => {
         await expect(bridge.callEndpoint(request)).resolves.toBeUndefined();
     });
 
+    it("passes async tokens", async () => {
+        const tokenProvider: () => Promise<string> = jest.fn().mockReturnValueOnce(Promise.resolve(token));
+        bridge = new FetchBridge({ baseUrl, token: tokenProvider, fetch: undefined, userAgent });
+
+        const request: IHttpEndpointOptions = {
+            endpointName: "a",
+            endpointPath: "a/",
+            method: "GET",
+            pathArguments: [],
+            queryArguments: {},
+        };
+        const expectedUrl = `${baseUrl}/a/`;
+        const expectedFetchRequest = createFetchRequest({
+            method: "GET",
+            responseMediaType: request.responseMediaType,
+        });
+        const expectedFetchResponse = createFetchResponse(undefined, 204);
+        mockFetch(expectedUrl, expectedFetchRequest, expectedFetchResponse);
+        await expect(bridge.callEndpoint(request)).resolves.toBeUndefined();
+    });
+
     it("passes headers", async () => {
         const request: IHttpEndpointOptions = {
             endpointName: "a",

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -45,7 +45,7 @@ export interface IFetchBridgeParams {
      * This will be logged in receiving service's request logs as params.User-Agent
      */
     userAgent: IUserAgent | IUserAgent[] | Array<Supplier<IUserAgent>>;
-    token?: string | Supplier<string>;
+    token?: string | Supplier<string> | Supplier<Promise<string>>;
     fetch?: FetchFunction;
 }
 
@@ -58,7 +58,7 @@ export class FetchBridge implements IHttpApiBridge {
     private static ACCEPT_HEADER = "accept";
 
     private readonly getBaseUrl: Supplier<string>;
-    private readonly getToken: Supplier<string | undefined>;
+    private readonly getToken: Supplier<string | Promise<string> | undefined>;
     private readonly fetch: FetchFunction | undefined;
     private readonly userAgentSuppliers: Array<Supplier<IUserAgent>>;
 
@@ -162,7 +162,7 @@ export class FetchBridge implements IHttpApiBridge {
         }
     }
 
-    private makeFetchCall(params: IHttpEndpointOptions): Promise<IFetchResponse> {
+    private async makeFetchCall(params: IHttpEndpointOptions): Promise<IFetchResponse> {
         const query = this.buildQueryString(params.queryArguments);
         const url = `${this.getBaseUrl()}/${this.buildPath(params)}${query.length > 0 ? `?${query}` : ""}`;
         const { data, headers = {}, method, requestMediaType, responseMediaType } = params;
@@ -184,7 +184,7 @@ export class FetchBridge implements IHttpApiBridge {
             method,
         };
 
-        const token = this.getToken();
+        const token = await this.getToken();
         if (token !== undefined) {
             fetchRequestInit.headers = { ...fetchRequestInit.headers, Authorization: `Bearer ${token}` };
         }


### PR DESCRIPTION
## Before this PR
For some auth providers (e.g. auth0) the token is provided via an async function. (See https://auth0.com/docs/quickstart/spa/react/02-calling-an-api#get-an-access-token)

## After this PR
==COMMIT_MSG==
Allow supplying the fetch bridge token via an async supplier.
==COMMIT_MSG==
