### PR TITLE
Fix isConjureError for nullish values and add tests

### DIFF
--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConjureError, ConjureErrorType } from "../error";
+import { ConjureError, ConjureErrorType, isConjureError } from "../error";
 
 const body = {
     errorCode: "NOT_FOUND",
@@ -70,5 +70,23 @@ describe("ConjureError", () => {
                 ),
             );
         });
+    });
+});
+
+describe("isConjureError", () => {
+    it("handles null errors", () => {
+        expect(isConjureError(null)).toBe(false);
+    });
+
+    it("handles undefined errors", () => {
+        expect(isConjureError(undefined)).toBe(false);
+    });
+
+    it("handles non-Conjure errors", () => {
+        expect(isConjureError(new Error("I'm an error"))).toBe(false);
+    });
+
+    it("handles Conjure errors", () => {
+        expect(isConjureError(new ConjureError(ConjureErrorType.Status, undefined, 400, body))).toBe(true);
     });
 });

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -49,9 +49,20 @@ export class ConjureError<E> {
     }
 }
 
-export function isConjureError(error: any): error is ConjureError<never> {
+export function isConjureError(error: unknown): error is ConjureError<never> {
+    if (error == null) {
+        return false;
+    }
+
+    if (error instanceof ConjureError) {
+        return true;
+    }
+
+    const errorPrototype = Object.getPrototypeOf(error);
+
     return (
-        error instanceof ConjureError ||
-        (error.__proto__ && error.__proto__.constructor && error.__proto__.constructor.name === ConjureError.name)
+        errorPrototype != null &&
+        errorPrototype.constructor != null &&
+        errorPrototype.constructor.name === ConjureError.name
     );
 }


### PR DESCRIPTION
## Before this PR
`isConjureError(null)` and `isConjureError(undefined)` would throw type errors:

```
TypeError: Cannot read property '__proto__' of null
```

## After this PR
- I refactored `isConjureError` to handle `unknown` inputs rather than just `any`.
- I added tests

==COMMIT_MSG==
Fix isConjureError handling of null/undefined values.
==COMMIT_MSG==

## Possible downsides?
N/A
