### PR TITLE
remove webstreams polyfill

### DIFF
--- a/packages/conjure-client/package.json
+++ b/packages/conjure-client/package.json
@@ -52,8 +52,5 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:palantir/conjure-typescript-runtime.git"
-  },
-  "dependencies": {
-    "web-streams-polyfill": "^2.0.6"
   }
 }

--- a/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
+++ b/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import "web-streams-polyfill";
-
 export function blobToReadableStream(blobPromise: Promise<Blob>): ReadableStream<Uint8Array> {
     return new ReadableStream({
         start: controller => {

--- a/packages/conjure-client/src/testBootstrap.js
+++ b/packages/conjure-client/src/testBootstrap.js
@@ -18,7 +18,6 @@
 // tslint:disable no-var-requires
 require("es6-shim");
 require("whatwg-fetch");
-require("web-streams-polyfill");
 // tslint:enable no-var-requires
 
 window.fetch = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9108,11 +9108,6 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.0.6.tgz#76e0504b4f15a6310cfc9e78e27637b648f9741e"
-  integrity sha512-nXOi4fBykO4LzyQhZX3MAGib635KGZBoNTkNXrNIkz0zthEf2QokEWxRb0H632xNLDWtHFb1R6dFGzksjYMSDw==
-
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
## Before this PR
We pulled in web-streams-polyfill to support receiving binary responses from servers. from the looks of it https://developer.mozilla.org/en-US/docs/Web/API/Streams_API#browser_compatibility it seems like ever modern browser now supports web-streams.

The polyfill ended up just being bloat and the version that we were depending on was wildly out of date (2.0.6 is 2 years old, 3.2.1 is latest)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
remove webstreams polyfill
==COMMIT_MSG==

## Possible downsides?
It may break someone using ie

