### PR TITLE
only use ponyfilled ReadableStream when necessary

### DIFF
--- a/packages/conjure-client/package.json
+++ b/packages/conjure-client/package.json
@@ -15,7 +15,7 @@
     "downloadTestServer": "./scripts/download-test-server.sh",
     "generateSpecBindings": "./scripts/generate-test-bindings.sh",
     "lint": "tslint 'src/**/*.ts*' --project ./src/tsconfig.json",
-    "lint-fix": "lint --fix",
+    "lint-fix": "yarn lint --fix",
     "test": "yarn downloadConjureTypeScript && yarn downloadTestServer && yarn generateSpecBindings && npm-run-all test:unit test:integration",
     "test:integration": "./scripts/run-integration-tests.sh",
     "test:unit": "jest --config ./jest.config.js --rootDir ./",

--- a/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
+++ b/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
@@ -17,9 +17,7 @@
 
 import { ReadableStream as PonyfilledReadableStream } from "web-streams-polyfill/ponyfill";
 
-export function blobToReadableStream(
-    blobPromise: Promise<Blob>,
-): ReadableStream<Uint8Array> | PonyfilledReadableStream<Uint8Array> {
+export function blobToReadableStream(blobPromise: Promise<Blob>): ReadableStream<Uint8Array> {
     const underlyingSource = {
         start: (controller: ReadableStreamDefaultController<Uint8Array>) => {
             const reader = new FileReader();
@@ -33,6 +31,6 @@ export function blobToReadableStream(
         },
     };
     return typeof ReadableStream === "undefined"
-        ? new PonyfilledReadableStream<Uint8Array>(underlyingSource)
+        ? ((new PonyfilledReadableStream<Uint8Array>(underlyingSource) as unknown) as ReadableStream<Uint8Array>)
         : new ReadableStream(underlyingSource);
 }

--- a/packages/conjure-client/tslint.json
+++ b/packages/conjure-client/tslint.json
@@ -7,6 +7,9 @@
     "file-header": [true,
       "Copyright \\d{4} Palantir Technologies, Inc."
     ],
+    "no-submodule-imports": {
+        "options": ["web-streams-polyfill/ponyfill"]
+    },
     "object-literal-sort-keys": false
   },
   "linterOptions": {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`web-streams-polyfill` doesn't include any checks to see if the browser it's running in has native streams. This causes conflicts between the native streams and the polyfilled ones.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now use the ponyfilled `ReadableStream` from `web-streams-polyfill` only if the browser doesn't have `ReadableStream`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This already existed, but `web-streams-polyfill` will still get loaded even if it's unused.

