### PR TITLE
upgrade `web-streams-polyfill`

### DIFF
--- a/packages/conjure-client/package.json
+++ b/packages/conjure-client/package.json
@@ -54,6 +54,6 @@
     "url": "git@github.com:palantir/conjure-typescript-runtime.git"
   },
   "dependencies": {
-    "web-streams-polyfill": "^2.0.6"
+    "web-streams-polyfill": "^3.2.1"
   }
 }

--- a/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
+++ b/packages/conjure-client/src/fetchBridge/blobReadableStreamAdapter.ts
@@ -31,6 +31,6 @@ export function blobToReadableStream(blobPromise: Promise<Blob>): ReadableStream
         },
     };
     return typeof ReadableStream === "undefined"
-        ? ((new PonyfilledReadableStream<Uint8Array>(underlyingSource) as unknown) as ReadableStream<Uint8Array>)
+        ? (new PonyfilledReadableStream<Uint8Array>(underlyingSource) as ReadableStream<Uint8Array>)
         : new ReadableStream(underlyingSource);
 }

--- a/packages/conjure-client/src/tsconfig.json
+++ b/packages/conjure-client/src/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "removeComments": false,
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "stripInternal": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8871,10 +8871,10 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.0.6.tgz#76e0504b4f15a6310cfc9e78e27637b648f9741e"
-  integrity sha512-nXOi4fBykO4LzyQhZX3MAGib635KGZBoNTkNXrNIkz0zthEf2QokEWxRb0H632xNLDWtHFb1R6dFGzksjYMSDw==
+web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This is stacked on top of https://github.com/palantir/conjure-typescript-runtime/pull/151 (filter down to the last 3 commits).

This upgrade brings our ponyfilled `ReadableStream` closer to the whatwg spec, and that actually makes the typings a bit more similar to the native `ReadableStream` (we don't need to cast as `unknown` anymore).

This PR also turns on `skipLibCheck` in our `tsconfig`, since there seems to be a small type issue in `web-streams-polyfill`