### PR TITLE
allow explicitly requesting response body be left as binary

### DIFF
--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -126,7 +126,10 @@ export class FetchBridge implements IHttpApiBridge {
 
             const contentType =
                 response.headers.get("Content-Type") != null ? (response.headers.get("Content-Type") as string) : "";
-            if ((contentType.includes(MediaType.APPLICATION_OCTET_STREAM) || params.forceBinaryResponseBody) && params.binaryAsStream) {
+            if (
+                (contentType.includes(MediaType.APPLICATION_OCTET_STREAM) || params.forceBinaryResponseBody) &&
+                params.binaryAsStream
+            ) {
                 return this.handleBinaryResponseBody(response) as any;
             }
 

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -126,12 +126,14 @@ export class FetchBridge implements IHttpApiBridge {
 
             const contentType =
                 response.headers.get("Content-Type") != null ? (response.headers.get("Content-Type") as string) : "";
-            if (contentType.includes(MediaType.APPLICATION_OCTET_STREAM) && params.binaryAsStream) {
+            if ((contentType.includes(MediaType.APPLICATION_OCTET_STREAM) || params.forceBinaryResponseBody) && params.binaryAsStream) {
                 return this.handleBinaryResponseBody(response) as any;
             }
 
             let bodyPromise;
-            if (contentType.includes(MediaType.APPLICATION_JSON)) {
+            if (params.forceBinaryResponseBody) {
+                bodyPromise = response.blob();
+            } else if (contentType.includes(MediaType.APPLICATION_JSON)) {
                 bodyPromise = response.json();
             } else if (contentType.includes(MediaType.APPLICATION_OCTET_STREAM)) {
                 bodyPromise = response.blob();

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -48,6 +48,9 @@ export interface IHttpEndpointOptions {
 
     /** return binary response as web stream */
     binaryAsStream?: boolean;
+
+    /** Force binary response body. Recommended to use this together with `responseMediaType`. */
+    forceBinaryResponseBody?: boolean;
 }
 
 export enum MediaType {


### PR DESCRIPTION
(rather than the current default of assuming text)

## Before this PR
When trying to hit endpoints that return media (e.g. `application/pdf`, `image/png`) the current behaviour is to fall back to treating this as text (https://github.com/palantir/conjure-typescript-runtime/blob/790523e1ca558610a0366499c7ec31f35b7fa74f/packages/conjure-client/src/fetchBridge/fetchBridge.ts#L139) 

Only responses served with `Content-Type: application/octet-stream` are unmangled.

## After this PR
Introduce a new field in `IHttpEndpointOptions` which allows forcing the response body to be binary.

==COMMIT_MSG==
Introduce a new field in `IHttpEndpointOptions` which allows forcing the response body to be binary.
==COMMIT_MSG==
