### PR TITLE
support binary response types in fetch bridge

### DIFF
--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -300,19 +300,10 @@ export class FetchBridge implements IHttpApiBridge {
     }
 
     private isBinaryMedia(contentType: string): boolean {
-        if (contentType.includes("image/")) {
-            return true;
-        }
-
-        if (contentType.includes("audio/")) {
-            return true;
-        }
-
-        if (contentType.includes("video/")) {
-            return true;
-        }
-
         return (
+            contentType.includes("image/") ||
+            contentType.includes("audio/") ||
+            contentType.includes("video/") ||
             contentType.includes("application/pdf") ||
             contentType.includes("application/dicom") ||
             contentType.includes("application/vnd.nitf")

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -126,14 +126,17 @@ export class FetchBridge implements IHttpApiBridge {
 
             const contentType =
                 response.headers.get("Content-Type") != null ? (response.headers.get("Content-Type") as string) : "";
-            if (contentType.includes(MediaType.APPLICATION_OCTET_STREAM) && params.binaryAsStream) {
+            if (
+                (contentType.includes(MediaType.APPLICATION_OCTET_STREAM) || this.isBinaryMedia(contentType)) &&
+                params.binaryAsStream
+            ) {
                 return this.handleBinaryResponseBody(response) as any;
             }
 
             let bodyPromise;
             if (contentType.includes(MediaType.APPLICATION_JSON)) {
                 bodyPromise = response.json();
-            } else if (contentType.includes(MediaType.APPLICATION_OCTET_STREAM)) {
+            } else if (contentType.includes(MediaType.APPLICATION_OCTET_STREAM) || this.isBinaryMedia(contentType)) {
                 bodyPromise = response.blob();
             } else {
                 bodyPromise = response.text();
@@ -294,5 +297,25 @@ export class FetchBridge implements IHttpApiBridge {
         }
         // TODO(forozco): use safe errors
         throw new Error("Unexpected media type " + value);
+    }
+
+    private isBinaryMedia(contentType: string): boolean {
+        if (contentType.includes("image/")) {
+            return true;
+        }
+
+        if (contentType.includes("audio/")) {
+            return true;
+        }
+
+        if (contentType.includes("video/")) {
+            return true;
+        }
+
+        return (
+            contentType.includes("application/pdf") ||
+            contentType.includes("application/dicom") ||
+            contentType.includes("application/vnd.nitf")
+        );
     }
 }

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -35,7 +35,7 @@ export interface IHttpEndpointOptions {
     requestMediaType?: MediaType;
 
     /** MIME type of the expected server response, often "application/json" or "application/octet-stream" */
-    responseMediaType?: string;
+    responseMediaType?: MediaType;
 
     /** Values to be interpolated into the endpointPath. */
     pathArguments: any[];

--- a/packages/conjure-client/src/httpApiBridge.ts
+++ b/packages/conjure-client/src/httpApiBridge.ts
@@ -35,7 +35,7 @@ export interface IHttpEndpointOptions {
     requestMediaType?: MediaType;
 
     /** MIME type of the expected server response, often "application/json" or "application/octet-stream" */
-    responseMediaType?: MediaType;
+    responseMediaType?: string;
 
     /** Values to be interpolated into the endpointPath. */
     pathArguments: any[];


### PR DESCRIPTION
alt approach to https://github.com/palantir/conjure-typescript-runtime/pull/170/files

## Before this PR
When trying to hit endpoints that return media (e.g. `application/pdf`, `image/png`) the current behaviour is to fall back to treating this as text (https://github.com/palantir/conjure-typescript-runtime/blob/790523e1ca558610a0366499c7ec31f35b7fa74f/packages/conjure-client/src/fetchBridge/fetchBridge.ts#L139) 

Only responses served with `Content-Type: application/octet-stream` are unmangled.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Correctly return binary responses for a larger number of media content types (beyond application/octet-stream)
==COMMIT_MSG==
