### PR TITLE
Fix npm publishing on later versions of npm by changing `.npmrc` location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - deploy:
           command: |
             if echo "${CIRCLE_TAG}" | grep -Eq '[0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)*'; then
+              ./scripts/setup-publishing-permissions.sh
               yarn circle-publish
             fi
 

--- a/packages/conjure-client/scripts/circle-publish-npm
+++ b/packages/conjure-client/scripts/circle-publish-npm
@@ -11,12 +11,6 @@ fi
 # Defend against yarn adding enviroment variables for config  https://github.com/yarnpkg/yarn/issues/4475
 unset $(env | awk -F= '$1 ~ /^npm_/ {print $1}')
 
-# Generate npmrc, ensure it is readable
-set +x
-echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
-set -x
-chmod +r .npmrc
-
 # Change package version to latest tag
 npm version "$CIRCLE_TAG" --no-git-tag-version
 

--- a/scripts/setup-publishing-permissions.sh
+++ b/scripts/setup-publishing-permissions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+if [ -z ${CIRCLECI+x} ]; then
+    echo "Not on Circle; refusing to run."
+    exit 1
+fi
+
+# Generate npmrc, ensure it is readable
+set +x
+echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+set -x
+chmod +r .npmrc


### PR DESCRIPTION
## Before this PR
Publishing is currently failing in this repo: https://app.circleci.com/pipelines/github/palantir/conjure-typescript-runtime/183/workflows/60abdce7-b705-4dc3-88d3-23750d4770f9/jobs/488

```
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/
npm ERR! need auth You need to authorize this machine using `npm adduser`
```

I believe this is due to:

```
+ npm publish --access public
npm WARN ignoring workspace config at /home/circleci/project/packages/conjure-client/.npmrc 
```

## After this PR

Instead of setting `.npmrc` at `packages/conjure-client/.npmrc`, let's generate it at the workspace root.

I didn't investigate too deep, but I'm guessing a newer `npm` version on CircleCI started ignoring subproject-specific `.npmrc` files for publishing.

