### PR TITLE
Update isConjureError return

### DIFF
--- a/packages/conjure-client/changelog/@unreleased/pr-175.v2.yml
+++ b/packages/conjure-client/changelog/@unreleased/pr-175.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Updated the isConjureError type guard return type to more accurately
+    indicate that the error body type is unknown. JSON error responses are already
+    parsed and so the error body may be an object (or other primitive), not just a
+    string.
+  links:
+  - https://github.com/palantir/conjure-typescript-runtime/pull/175

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -49,7 +49,7 @@ export class ConjureError<E> {
     }
 }
 
-export function isConjureError(error: unknown): error is ConjureError<never> {
+export function isConjureError(error: unknown): error is ConjureError<unknown> {
     if (error == null) {
         return false;
     }


### PR DESCRIPTION
Fixes #118 

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Presumably conjure didn't do parsing of JSON response bodies for errors at some point in the past and so `ConjureError.body` was expected to just be strings. But this isn't true (any more), lots of error handling code accesses error fields like `(error.body as any)?.someField`.

I noticed this as I was trying to do a slightly safer `error.body != null && typeof error.body === "object"` first.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updated the isConjureError type guard return type to more accurately indicate that the error body type is unknown. JSON error responses are already parsed and so the error body may be an object (or other primitive), not just a string.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
I can't imagine this would break where `never` was acceptable?
