### PR TITLE
Accept suppliers returning an array of user agents

### DIFF
--- a/packages/conjure-client/changelog/@unreleased/pr-183.v2.yml
+++ b/packages/conjure-client/changelog/@unreleased/pr-183.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Accept suppliers returning an array of user agents
+  links:
+  - https://github.com/palantir/conjure-typescript-runtime/pull/183

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -25,6 +25,7 @@ import { FetchBridge } from "../fetchBridge";
 const baseUrl = "https://host.domain/path";
 const token = "TOKEN";
 const userAgent: IUserAgent = { productName: "foo", productVersion: "1.2.3" };
+const userAgent2: IUserAgent = { productName: "bar", productVersion: "1.2.3" };
 const ACCEPT_HEADER = "accept";
 
 interface IMockResponseObject {
@@ -55,12 +56,12 @@ describe("FetchBridgeImpl", () => {
         }, fetchResponse);
     }
 
-    function verifyFetchUserAgent() {
+    function verifyFetchUserAgent(expectedUserAgent: string = `foo/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`) {
         expect(fetchMock.calls.length).toBe(1);
         const [, actualRequest] = fetchMock.lastCall();
         // fetch-mock does not provide reasonable types here, the default type is Int8Array
         const fetchUserAgent = (actualRequest.headers as any)["Fetch-User-Agent"];
-        expect(fetchUserAgent).toBe(`foo/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`);
+        expect(fetchUserAgent).toBe(expectedUserAgent);
     }
 
     beforeEach(() => {
@@ -544,6 +545,14 @@ describe("FetchBridgeImpl", () => {
             await fetchBridge.callEndpoint(request);
 
             verifyFetchUserAgent();
+        });
+
+        it("for array of user agent suppliers that return an array", async () => {
+            const fetchBridge = new FetchBridge({ baseUrl, token, fetch: undefined, userAgent: [() => [userAgent, userAgent2]] });
+
+            await fetchBridge.callEndpoint(request);
+
+            verifyFetchUserAgent(`foo/1.2.3 bar/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`);
         });
 
         it("for changing user agent", async () => {

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -26,6 +26,7 @@ const baseUrl = "https://host.domain/path";
 const token = "TOKEN";
 const userAgent: IUserAgent = { productName: "foo", productVersion: "1.2.3" };
 const userAgent2: IUserAgent = { productName: "bar", productVersion: "1.2.3" };
+const userAgent3: IUserAgent = { productName: "baz", productVersion: "1.2.3" };
 const ACCEPT_HEADER = "accept";
 
 interface IMockResponseObject {
@@ -549,17 +550,17 @@ describe("FetchBridgeImpl", () => {
             verifyFetchUserAgent();
         });
 
-        it("for array of user agent suppliers that return an array", async () => {
+        it("for array of user agent suppliers where some return an array", async () => {
             const fetchBridge = new FetchBridge({
                 baseUrl,
                 token,
                 fetch: undefined,
-                userAgent: [() => [userAgent, userAgent2]],
+                userAgent: [() => [userAgent, userAgent2], () => userAgent3],
             });
 
             await fetchBridge.callEndpoint(request);
 
-            verifyFetchUserAgent(`foo/1.2.3 bar/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`);
+            verifyFetchUserAgent(`foo/1.2.3 bar/1.2.3 baz/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`);
         });
 
         it("for changing user agent", async () => {

--- a/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
+++ b/packages/conjure-client/src/fetchBridge/__tests__/fetchBridgeTests.ts
@@ -56,7 +56,9 @@ describe("FetchBridgeImpl", () => {
         }, fetchResponse);
     }
 
-    function verifyFetchUserAgent(expectedUserAgent: string = `foo/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`) {
+    function verifyFetchUserAgent(
+        expectedUserAgent: string = `foo/1.2.3 conjure-typescript-runtime/${IMPLEMENTATION_VERSION}`,
+    ) {
         expect(fetchMock.calls.length).toBe(1);
         const [, actualRequest] = fetchMock.lastCall();
         // fetch-mock does not provide reasonable types here, the default type is Int8Array
@@ -548,7 +550,12 @@ describe("FetchBridgeImpl", () => {
         });
 
         it("for array of user agent suppliers that return an array", async () => {
-            const fetchBridge = new FetchBridge({ baseUrl, token, fetch: undefined, userAgent: [() => [userAgent, userAgent2]] });
+            const fetchBridge = new FetchBridge({
+                baseUrl,
+                token,
+                fetch: undefined,
+                userAgent: [() => [userAgent, userAgent2]],
+            });
 
             await fetchBridge.callEndpoint(request);
 

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -44,7 +44,7 @@ export interface IFetchBridgeParams {
      * All network requests will add this userAgent as a header param called 'Fetch-User-Agent'.
      * This will be logged in receiving service's request logs as params.User-Agent
      */
-    userAgent: IUserAgent | Array<IUserAgent | Supplier<IUserAgent | IUserAgent[]>>;
+    userAgent: IUserAgent | ReadonlyArray<IUserAgent | Supplier<IUserAgent | IUserAgent[]>>;
     token?: string | Supplier<string> | Supplier<Promise<string>>;
     fetch?: FetchFunction;
 }

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -44,7 +44,7 @@ export interface IFetchBridgeParams {
      * All network requests will add this userAgent as a header param called 'Fetch-User-Agent'.
      * This will be logged in receiving service's request logs as params.User-Agent
      */
-    userAgent: IUserAgent | IUserAgent[] | Array<Supplier<IUserAgent>>;
+    userAgent: IUserAgent | Array<IUserAgent | Supplier<IUserAgent | IUserAgent[]>>;
     token?: string | Supplier<string> | Supplier<Promise<string>>;
     fetch?: FetchFunction;
 }
@@ -60,7 +60,7 @@ export class FetchBridge implements IHttpApiBridge {
     private readonly getBaseUrl: Supplier<string>;
     private readonly getToken: Supplier<string | Promise<string> | undefined>;
     private readonly fetch: FetchFunction | undefined;
-    private readonly userAgentSuppliers: Array<Supplier<IUserAgent>>;
+    private readonly userAgentSuppliers: Array<Supplier<IUserAgent | IUserAgent[]>>;
 
     constructor(params: IFetchBridgeParams) {
         this.getBaseUrl = typeof params.baseUrl === "function" ? params.baseUrl : () => params.baseUrl as string;
@@ -212,7 +212,18 @@ export class FetchBridge implements IHttpApiBridge {
     }
 
     private getUserAgent(): UserAgent {
-        return new UserAgent(this.userAgentSuppliers.map(uaSupplier => uaSupplier()));
+        return new UserAgent(
+            this.userAgentSuppliers
+                .map(uaSupplier => uaSupplier())
+                .reduce((uas: IUserAgent[], ua) => {
+                    if (Array.isArray(ua)) {
+                        uas.push(...ua);
+                    } else {
+                        uas.push(ua);
+                    }
+                    return uas;
+                }, []),
+        );
     }
 
     private async handleBinaryResponseBody(response: IFetchResponse): Promise<ReadableStream<Uint8Array>> {


### PR DESCRIPTION
This PR widens the type of the user agent object accepted by the fetch bridge.

- Changing `IUserAgent[] | Array<Supplier<IUserAgent>>` to `Array<IUserAgent | Supplier<IUserAgent>>` means that we can now pass arrays that are a mix of `IUserAgent` and `Supplier<IUserAgent>` (so it's more flexible)
- Changing `Supplier<IUserAgent>` to `Supplier<IUserAgent | IUserAgent[]>` means that the suppliers are more powerful now, and they can return multiple user agents, or none
- Changing `Array` to `ReadonlyArray` offers even more flexibility