### PR TITLE
Update autorelease config to use standard release

### DIFF
--- a/.autorelease.yml
+++ b/.autorelease.yml
@@ -1,3 +1,3 @@
-type: local
-local:
-  repositoryType: default
+version: 3
+options:
+  repo_type: DEFAULT


### PR DESCRIPTION
This repo expects standard semver tags, rather than frontend style package@version releases, so we want to explicitly set the repo type.