### PR TITLE
Extend isBinaryMedia to recognize Office Open XML formats in fetch bridge

### DIFF
--- a/packages/conjure-client/changelog/@unreleased/pr-187.v2.yml
+++ b/packages/conjure-client/changelog/@unreleased/pr-187.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Open Office XML formats are now returned as binary through the fetch
+    bridge
+  links:
+  - https://github.com/palantir/conjure-typescript-runtime/pull/187

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -317,7 +317,10 @@ export class FetchBridge implements IHttpApiBridge {
             contentType.includes("video/") ||
             contentType.includes("application/pdf") ||
             contentType.includes("application/dicom") ||
-            contentType.includes("application/vnd.nitf")
+            contentType.includes("application/vnd.nitf") ||
+            contentType.includes("application/vnd.openxmlformats-officedocument.presentationml") ||
+            contentType.includes("application/vnd.openxmlformats-officedocument.spreadsheetml") ||
+            contentType.includes("application/vnd.openxmlformats-officedocument.wordprocessingml")
         );
     }
 }


### PR DESCRIPTION
## Before this PR
- Open Office XML formats were returned as a `String`

## After this PR
- Open Office XML formats are returned as a `Blob`


