### PR TITLE
Expose `qos` field in `ConjureError`

### DIFF
--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -37,6 +37,7 @@ describe("ConjureError", () => {
                             "errorCode": "NOT_FOUND",
                             "message": "Refer to the server logs"
                         },
+                        "headers": {},
                         "status": 400,
                         "type": "STATUS"
                     }`,
@@ -47,6 +48,7 @@ describe("ConjureError", () => {
         it("propagates known conjure headers, and includes the status and type", () => {
             const headers = new Headers({
                 "qos-retry-hint": "do-not-retry",
+                "qos-due-to": "custom",
                 "other": "header",
             });
             const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
@@ -56,7 +58,8 @@ describe("ConjureError", () => {
                 removeSpaces(
                     `{
                         "headers": {
-                            "qos-retry-hint": "do-not-retry"
+                            "qos-retry-hint": "do-not-retry",
+                            "qos-due-to": "custom"
                         },
                         "status": 400,
                         "type": "STATUS"
@@ -73,6 +76,7 @@ describe("ConjureError", () => {
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
+                        "headers": {},
                         "originalError": "I'm an error",
                         "status": 400,
                         "type": "STATUS"
@@ -86,6 +90,7 @@ describe("ConjureError", () => {
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
+                        "headers": {},
                         "type": "STATUS"
                     }`,
                 ),

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -46,7 +46,7 @@ describe("ConjureError", () => {
 
         it("stringifies the headers, and includes the status and type", () => {
             const headers = new Headers({
-                "qos-retry-hint": "do-not-retry"
+                "qos-retry-hint": "do-not-retry",
             });
             const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
             expect(removeSpaces(error.toString())).toEqual(

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -46,15 +46,15 @@ describe("ConjureError", () => {
 
         it("propagates QoS metadata, and includes the status and type", () => {
             const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, {
-                "QoS-Due-To": "custom",
-                "QoS-Retry-Hint": "do-not-retry",
+                dueTo: "custom",
+                retryHint: "do-not-retry",
             });
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
                         "qos": {
-                            "QoS-Due-To": "custom",
-                            "QoS-Retry-Hint": "do-not-retry"
+                            "dueTo": "custom",
+                            "retryHint": "do-not-retry"
                         },
                         "status": 400,
                         "type": "STATUS"

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -37,7 +37,6 @@ describe("ConjureError", () => {
                             "errorCode": "NOT_FOUND",
                             "message": "Refer to the server logs"
                         },
-                        "headers": {},
                         "status": 400,
                         "type": "STATUS"
                     }`,
@@ -45,22 +44,17 @@ describe("ConjureError", () => {
             );
         });
 
-        it("propagates known conjure headers, and includes the status and type", () => {
-            const headers = new Headers({
-                "qos-retry-hint": "do-not-retry",
-                "qos-due-to": "custom",
-                "other": "header",
+        it("propagates QoS metadata, and includes the status and type", () => {
+            const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, {
+                "QoS-Due-To": "custom",
+                "QoS-Retry-Hint": "do-not-retry",
             });
-            const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
-            expect(error.headers?.get("qos-retry-hint")).toEqual("do-not-retry");
-            expect(error.headers?.get("qos-due-to")).toEqual("custom");
-            expect(error.headers?.get("other")).toBeNull();
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
-                        "headers": {
-                            "qos-retry-hint": "do-not-retry",
-                            "qos-due-to": "custom"
+                        "qos": {
+                            "QoS-Due-To": "custom",
+                            "QoS-Retry-Hint": "do-not-retry"
                         },
                         "status": 400,
                         "type": "STATUS"
@@ -77,7 +71,6 @@ describe("ConjureError", () => {
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
-                        "headers": {},
                         "originalError": "I'm an error",
                         "status": 400,
                         "type": "STATUS"
@@ -91,7 +84,6 @@ describe("ConjureError", () => {
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{
-                        "headers": {},
                         "type": "STATUS"
                     }`,
                 ),

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -44,6 +44,24 @@ describe("ConjureError", () => {
             );
         });
 
+        it("stringifies the headers, and includes the status and type", () => {
+            const headers = new Headers({
+                "qos-retry-hint": "do-not-retry"
+            });
+            const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
+            expect(removeSpaces(error.toString())).toEqual(
+                removeSpaces(
+                    `{
+                        "headers": {
+                            "qos-retry-hint": "do-not-retry"
+                        },
+                        "status": 400,
+                        "type": "STATUS"
+                    }`,
+                ),
+            );
+        });
+
         it("uses the default string conversion for the originalError, if an originalError is defined", () => {
             const originalError = {
                 toString: () => "I'm an error",

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -53,6 +53,7 @@ describe("ConjureError", () => {
             });
             const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
             expect(error.headers?.get("qos-retry-hint")).toEqual("do-not-retry");
+            expect(error.headers?.get("qos-due-to")).toEqual("custom");
             expect(error.headers?.get("other")).toBeNull();
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -44,11 +44,14 @@ describe("ConjureError", () => {
             );
         });
 
-        it("stringifies the headers, and includes the status and type", () => {
+        it("propagates known conjure headers, and includes the status and type", () => {
             const headers = new Headers({
                 "qos-retry-hint": "do-not-retry",
+                "other": "header",
             });
             const error = new ConjureError(ConjureErrorType.Status, undefined, 400, undefined, headers);
+            expect(error.headers?.get("qos-retry-hint")).toEqual("do-not-retry");
+            expect(error.headers?.get("other")).toBeNull();
             expect(removeSpaces(error.toString())).toEqual(
                 removeSpaces(
                     `{

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -15,12 +15,9 @@
  * limitations under the License.
  */
 
-export const QOS_RETRY_HINT = "QoS-Retry-Hint";
-export const QOS_DUE_TO = "QoS-Due-To";
-
 export interface IQoSMetadata {
-    [QOS_RETRY_HINT]?: string;
-    [QOS_DUE_TO]?: string;
+    retryHint?: string;
+    dueTo?: string;
 }
 
 export enum ConjureErrorType {

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -29,7 +29,13 @@ export class ConjureError<E> {
     public readonly body?: string | E;
     public readonly headers?: Headers;
 
-    constructor(errorType: ConjureErrorType, originalError?: any, status?: number, body?: string | E, headers?: Headers) {
+    constructor(
+        errorType: ConjureErrorType,
+        originalError?: any,
+        status?: number,
+        body?: string | E,
+        headers?: Headers,
+    ) {
         this.type = errorType;
         this.originalError = originalError;
         this.status = status;

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const QOS_RETRY_HINT_HEADER = "QoS-Retry-Hint";
+const CONJURE_HEADERS = ["QoS-Retry-Hint", "QoS-Due-To"];
 
 export enum ConjureErrorType {
     Network = "NETWORK",
@@ -43,16 +43,13 @@ export class ConjureError<E> {
         this.status = status;
         this.body = body;
 
-        if (headers == null) {
-            this.headers = headers;
-            return;
-        }
-
         const conjureHeaders = new Headers();
-        const qosRetryHint = headers.get(QOS_RETRY_HINT_HEADER);
-        if (qosRetryHint != null) {
-            conjureHeaders.set(QOS_RETRY_HINT_HEADER, qosRetryHint);
-        }
+        CONJURE_HEADERS.forEach(conjureHeaderKey => {
+            const conjureHeaderValue = headers?.get(conjureHeaderKey);
+            if (conjureHeaderValue != null) {
+                conjureHeaders.set(conjureHeaderKey, conjureHeaderValue);
+            }
+        });
         this.headers = conjureHeaders;
     }
 

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-const CONJURE_HEADERS = ["QoS-Retry-Hint", "QoS-Due-To"];
+export const QOS_RETRY_HINT = "QoS-Retry-Hint";
+export const QOS_DUE_TO = "QoS-Due-To";
+
+export interface QoSMetadata {
+    [QOS_RETRY_HINT]?: string;
+    [QOS_DUE_TO]?: string;
+}
 
 export enum ConjureErrorType {
     Network = "NETWORK",
@@ -29,54 +35,34 @@ export class ConjureError<E> {
     public readonly originalError?: any;
     public readonly status?: number;
     public readonly body?: string | E;
-    public readonly headers?: Headers;
+    public readonly qos?: QoSMetadata;
 
     constructor(
         errorType: ConjureErrorType,
         originalError?: any,
         status?: number,
         body?: string | E,
-        headers?: Headers,
+        qos?: QoSMetadata,
     ) {
         this.type = errorType;
         this.originalError = originalError;
         this.status = status;
         this.body = body;
-
-        const conjureHeaders = new Headers();
-        CONJURE_HEADERS.forEach(conjureHeaderKey => {
-            const conjureHeaderValue = headers?.get(conjureHeaderKey);
-            if (conjureHeaderValue != null) {
-                conjureHeaders.set(conjureHeaderKey, conjureHeaderValue);
-            }
-        });
-        this.headers = conjureHeaders;
+        this.qos = qos;
     }
 
     public toString() {
         return JSON.stringify(
             {
                 body: this.body,
-                headers: this.getHeadersObject(),
                 originalError: this.originalError && this.originalError.toString(),
+                qos: this.qos,
                 status: this.status,
                 type: this.type,
             },
             null,
             "  ",
         );
-    }
-
-    private getHeadersObject(): Record<string, string> | undefined {
-        if (this.headers == null) {
-            return;
-        }
-
-        const headersObj: Record<string, string> = {};
-        this.headers.forEach((value, key) => {
-            headersObj[key] = value;
-        });
-        return headersObj;
     }
 }
 

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -18,7 +18,7 @@
 export const QOS_RETRY_HINT = "QoS-Retry-Hint";
 export const QOS_DUE_TO = "QoS-Due-To";
 
-export interface QoSMetadata {
+export interface IQoSMetadata {
     [QOS_RETRY_HINT]?: string;
     [QOS_DUE_TO]?: string;
 }

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -27,18 +27,21 @@ export class ConjureError<E> {
     public readonly originalError?: any;
     public readonly status?: number;
     public readonly body?: string | E;
+    public readonly headers?: Headers;
 
-    constructor(errorType: ConjureErrorType, originalError?: any, status?: number, body?: string | E) {
+    constructor(errorType: ConjureErrorType, originalError?: any, status?: number, body?: string | E, headers?: Headers) {
         this.type = errorType;
         this.originalError = originalError;
         this.status = status;
         this.body = body;
+        this.headers = headers;
     }
 
     public toString() {
         return JSON.stringify(
             {
                 body: this.body,
+                headers: this.getHeadersObject(),
                 originalError: this.originalError && this.originalError.toString(),
                 status: this.status,
                 type: this.type,
@@ -46,6 +49,18 @@ export class ConjureError<E> {
             null,
             "  ",
         );
+    }
+
+    private getHeadersObject(): Record<string, string> | undefined {
+        if (this.headers == null) {
+            return;
+        }
+
+        const headersObj: Record<string, string> = {};
+        this.headers.forEach((value, key) => {
+            headersObj[key] = value;
+        });
+        return headersObj;
     }
 }
 

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+const QOS_RETRY_HINT_HEADER = "QoS-Retry-Hint";
+
 export enum ConjureErrorType {
     Network = "NETWORK",
     Other = "OTHER",
@@ -40,7 +42,18 @@ export class ConjureError<E> {
         this.originalError = originalError;
         this.status = status;
         this.body = body;
-        this.headers = headers;
+
+        if (headers == null) {
+            this.headers = headers;
+            return;
+        }
+
+        const conjureHeaders = new Headers();
+        const qosRetryHint = headers.get(QOS_RETRY_HINT_HEADER);
+        if (qosRetryHint != null) {
+            conjureHeaders.set(QOS_RETRY_HINT_HEADER, qosRetryHint);
+        }
+        this.headers = conjureHeaders;
     }
 
     public toString() {

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -35,14 +35,14 @@ export class ConjureError<E> {
     public readonly originalError?: any;
     public readonly status?: number;
     public readonly body?: string | E;
-    public readonly qos?: QoSMetadata;
+    public readonly qos?: IQoSMetadata;
 
     constructor(
         errorType: ConjureErrorType,
         originalError?: any,
         status?: number,
         body?: string | E,
-        qos?: QoSMetadata,
+        qos?: IQoSMetadata,
     ) {
         this.type = errorType;
         this.originalError = originalError;

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -146,7 +146,7 @@ export class FetchBridge implements IHttpApiBridge {
             try {
                 body = await bodyPromise;
             } catch (error) {
-                throw new ConjureError(ConjureErrorType.Parse, error, response.status);
+                throw new ConjureError(ConjureErrorType.Parse, error, response.status, undefined, response.headers);
             }
 
             if (!response.ok) {

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -150,7 +150,7 @@ export class FetchBridge implements IHttpApiBridge {
             }
 
             if (!response.ok) {
-                throw new ConjureError(ConjureErrorType.Status, undefined, response.status, body);
+                throw new ConjureError(ConjureErrorType.Status, undefined, response.status, body, response.headers);
             }
 
             return body;

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -15,11 +15,14 @@
  * limitations under the License.
  */
 
-import { ConjureError, ConjureErrorType, IQoSMetadata, QOS_DUE_TO, QOS_RETRY_HINT } from "../errors";
+import { ConjureError, ConjureErrorType, IQoSMetadata } from "../errors";
 import { IMPLEMENTATION_VERSION } from "../generated";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../httpApiBridge";
 import { IUserAgent, UserAgent } from "../userAgent";
 import { blobToReadableStream } from "./blobReadableStreamAdapter";
+
+const QOS_RETRY_HINT_HEADER = "QoS-Retry-Hint";
+const QOS_DUE_TO_HEADER = "QoS-Due-To";
 
 export interface IFetchBody {
     json(): Promise<any>;
@@ -240,8 +243,8 @@ export class FetchBridge implements IHttpApiBridge {
 
     private getQoSMetadataFromHeaders(headers: Headers): IQoSMetadata {
         return {
-            [QOS_RETRY_HINT]: headers.get(QOS_RETRY_HINT) ?? undefined,
-            [QOS_DUE_TO]: headers.get(QOS_DUE_TO) ?? undefined,
+            retryHint: headers.get(QOS_RETRY_HINT_HEADER) ?? undefined,
+            dueTo: headers.get(QOS_DUE_TO_HEADER) ?? undefined,
         };
     }
 

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConjureError, ConjureErrorType } from "../errors";
+import { ConjureError, ConjureErrorType, QOS_DUE_TO, QOS_RETRY_HINT, QoSMetadata } from "../errors";
 import { IMPLEMENTATION_VERSION } from "../generated";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../httpApiBridge";
 import { IUserAgent, UserAgent } from "../userAgent";
@@ -146,11 +146,23 @@ export class FetchBridge implements IHttpApiBridge {
             try {
                 body = await bodyPromise;
             } catch (error) {
-                throw new ConjureError(ConjureErrorType.Parse, error, response.status, undefined, response.headers);
+                throw new ConjureError(
+                    ConjureErrorType.Parse,
+                    error,
+                    response.status,
+                    undefined,
+                    this.getQoSMetadataFromHeaders(response.headers),
+                );
             }
 
             if (!response.ok) {
-                throw new ConjureError(ConjureErrorType.Status, undefined, response.status, body, response.headers);
+                throw new ConjureError(
+                    ConjureErrorType.Status,
+                    undefined,
+                    response.status,
+                    body,
+                    this.getQoSMetadataFromHeaders(response.headers),
+                );
             }
 
             return body;
@@ -224,6 +236,13 @@ export class FetchBridge implements IHttpApiBridge {
                     return uas;
                 }, []),
         );
+    }
+
+    private getQoSMetadataFromHeaders(headers: Headers): QoSMetadata {
+        return {
+            [QOS_RETRY_HINT]: headers.get(QOS_RETRY_HINT) ?? undefined,
+            [QOS_DUE_TO]: headers.get(QOS_DUE_TO) ?? undefined,
+        };
     }
 
     private async handleBinaryResponseBody(response: IFetchResponse): Promise<ReadableStream<Uint8Array>> {

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConjureError, ConjureErrorType, QOS_DUE_TO, QOS_RETRY_HINT, QoSMetadata } from "../errors";
+import { ConjureError, ConjureErrorType, QOS_DUE_TO, QOS_RETRY_HINT, IQoSMetadata } from "../errors";
 import { IMPLEMENTATION_VERSION } from "../generated";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../httpApiBridge";
 import { IUserAgent, UserAgent } from "../userAgent";
@@ -238,7 +238,7 @@ export class FetchBridge implements IHttpApiBridge {
         );
     }
 
-    private getQoSMetadataFromHeaders(headers: Headers): QoSMetadata {
+    private getQoSMetadataFromHeaders(headers: Headers): IQoSMetadata {
         return {
             [QOS_RETRY_HINT]: headers.get(QOS_RETRY_HINT) ?? undefined,
             [QOS_DUE_TO]: headers.get(QOS_DUE_TO) ?? undefined,

--- a/packages/conjure-client/src/fetchBridge/fetchBridge.ts
+++ b/packages/conjure-client/src/fetchBridge/fetchBridge.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConjureError, ConjureErrorType, QOS_DUE_TO, QOS_RETRY_HINT, IQoSMetadata } from "../errors";
+import { ConjureError, ConjureErrorType, IQoSMetadata, QOS_DUE_TO, QOS_RETRY_HINT } from "../errors";
 import { IMPLEMENTATION_VERSION } from "../generated";
 import { IHttpApiBridge, IHttpEndpointOptions, MediaType } from "../httpApiBridge";
 import { IUserAgent, UserAgent } from "../userAgent";


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Conjure-Java supports the `QoS-Retry-Hint` and `QoS-Due-To` headers to give clients more information about how they should retry requests. For example, a server can propagate a `QoS-Retry-Hint` of `do-not-retry`, which gives the client a hint that they should not retry a particular 429 response to prevent retry storms. Please see the relevant PR [here](https://github.com/palantir/conjure-java-runtime-api/pull/1231) to support this behavior in Conjure-Java.

## After this PR
After this PR, back-end Node.js clients that use Conjure-TypeScript will be able to access these headers to configure retry behavior.

Given that a request could have many response headers that could muddy the stringified version of the `ConjureError`, I've opted for an allow-list approach which only exposes well-known headers used by the Conjure framework.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

