### PR TITLE
Set target to `es2019`

### DIFF
--- a/packages/conjure-client/src/tsconfig.json
+++ b/packages/conjure-client/src/tsconfig.json
@@ -18,7 +18,7 @@
     "sourceMap": true,
     "strict": true,
     "stripInternal": true,
-    "target": "es5",
+    "target": "es2019",
     "outDir": "../lib"
   },
   "exclude": [


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`es5` is very old and means we lose out on using built-in ECMA features like generators and classes.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

