### PR TITLE
Make isConjureError recognise errors from duplicate copies of conjure-client

### DIFF
--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -108,4 +108,23 @@ describe("isConjureError", () => {
     it("handles Conjure errors", () => {
         expect(isConjureError(new ConjureError(ConjureErrorType.Status, undefined, 400, body))).toBe(true);
     });
+
+    it("brands instances with the global registry symbol", () => {
+        const brand = Symbol.for("com.palantir.conjure.ConjureError");
+        const error: object = new ConjureError(ConjureErrorType.Status, undefined, 400, body);
+        expect(brand in error && error[brand] === true).toBe(true);
+    });
+
+    it("handles Conjure errors thrown by a duplicate copy of conjure-client", () => {
+        // Simulate an error produced by a second, duplicate copy of this library: it carries the
+        // shared registry brand but is neither `instanceof` our ConjureError nor named "ConjureError",
+        // so only the brand check can recognise it.
+        const fromDuplicateCopy = {
+            [Symbol.for("com.palantir.conjure.ConjureError")]: true,
+            type: ConjureErrorType.Status,
+            body,
+        };
+        expect(fromDuplicateCopy instanceof ConjureError).toBe(false);
+        expect(isConjureError(fromDuplicateCopy)).toBe(true);
+    });
 });

--- a/packages/conjure-client/src/errors/__tests__/errorTests.ts
+++ b/packages/conjure-client/src/errors/__tests__/errorTests.ts
@@ -110,7 +110,7 @@ describe("isConjureError", () => {
     });
 
     it("brands instances with the global registry symbol", () => {
-        const brand = Symbol.for("com.palantir.conjure.ConjureError");
+        const brand = Symbol.for("instanceof com.palantir.conjure.ConjureError");
         const error: object = new ConjureError(ConjureErrorType.Status, undefined, 400, body);
         expect(brand in error && error[brand] === true).toBe(true);
     });
@@ -120,7 +120,7 @@ describe("isConjureError", () => {
         // shared registry brand but is neither `instanceof` our ConjureError nor named "ConjureError",
         // so only the brand check can recognise it.
         const fromDuplicateCopy = {
-            [Symbol.for("com.palantir.conjure.ConjureError")]: true,
+            [Symbol.for("instanceof com.palantir.conjure.ConjureError")]: true,
             type: ConjureErrorType.Status,
             body,
         };

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -32,12 +32,15 @@ export enum ConjureErrorType {
  * `instanceof` fails because each copy defines its own `ConjureError` class. `Symbol.for` resolves to the
  * same symbol across copies; see
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for.
+ *
+ * The `"instanceof "` prefix makes the symbol self-describing: an object carrying it reads as
+ * "instanceof com.palantir.conjure.ConjureError", i.e. it declares itself to be a `ConjureError`.
  */
-const CONJURE_ERROR_BRAND = Symbol.for("com.palantir.conjure.ConjureError");
+const IS_CONJURE_ERROR_SYMBOL = Symbol.for("instanceof com.palantir.conjure.ConjureError");
 
 export class ConjureError<E> {
     // On the prototype rather than the instance, so the brand doesn't clutter every instance.
-    public get [CONJURE_ERROR_BRAND](): true {
+    public get [IS_CONJURE_ERROR_SYMBOL](): true {
         return true;
     }
 
@@ -86,13 +89,13 @@ export function isConjureError(error: unknown): error is ConjureError<unknown> {
         return true;
     }
 
-    // An error from a different copy of the library, recognised by the shared brand. (See CONJURE_ERROR_BRAND.)
-    if (typeof error === "object" && CONJURE_ERROR_BRAND in error && error[CONJURE_ERROR_BRAND] === true) {
+    // An error from a different copy of the library, recognised by the shared brand. (See IS_CONJURE_ERROR_SYMBOL.)
+    if (typeof error === "object" && IS_CONJURE_ERROR_SYMBOL in error && error[IS_CONJURE_ERROR_SYMBOL] === true) {
         return true;
     }
 
-    // Back-compat for copies that predate the brand: match the class name. Brittle (minifiers mangle names)
-    // and removable once every producer emits the brand.
+    // Back-compat for an older conjure-client version on the page that predates the brand: match the class
+    // name. Brittle (minifiers mangle names) and removable in a major version.
     const errorPrototype = Object.getPrototypeOf(error);
 
     return (

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -27,7 +27,25 @@ export enum ConjureErrorType {
     Status = "STATUS",
 }
 
+/**
+ * Brand stamped on every {@link ConjureError} instance so {@link isConjureError} can recognise errors
+ * thrown by a *different* copy of conjure-client on the page (e.g. a bundling/dedupe miss), where
+ * `instanceof` fails because each copy defines its own `ConjureError` class.
+ *
+ * It uses `Symbol.for` (the runtime-global symbol registry) rather than `Symbol()` so that every copy
+ * resolves this key to the *same* symbol; a plain class-name string would instead be unreliable because
+ * minifiers rename classes. Being a symbol, it is also skipped by `JSON.stringify`, `Object.keys`, and
+ * `for...in`, so it never leaks into serialized output.
+ */
+const CONJURE_ERROR_BRAND = Symbol.for("com.palantir.conjure.ConjureError");
+
 export class ConjureError<E> {
+    // Brands the prototype so isConjureError can detect ConjureErrors from other copies of the library,
+    // without stamping a symbol onto (and cluttering) every instance.
+    public get [CONJURE_ERROR_BRAND](): true {
+        return true;
+    }
+
     public readonly type: ConjureErrorType;
     public readonly originalError?: any;
     public readonly status?: number;
@@ -68,10 +86,21 @@ export function isConjureError(error: unknown): error is ConjureError<unknown> {
         return false;
     }
 
+    // Common case, and the cheapest check: an error from this same copy of the library, matched by its
+    // prototype. Tried first because the cross-copy paths below can only ever add to this result.
     if (error instanceof ConjureError) {
         return true;
     }
 
+    // A duplicate copy of the library defines its own `ConjureError` class, so the `instanceof` above
+    // can't see its instances; the shared brand is what lets us recognise them. (See CONJURE_ERROR_BRAND.)
+    if (typeof error === "object" && CONJURE_ERROR_BRAND in error && error[CONJURE_ERROR_BRAND] === true) {
+        return true;
+    }
+
+    // Back-compat for errors from copies of conjure-client that predate the brand: fall back to matching
+    // the class name. This is brittle (minifiers mangle class names) and can go once every producer
+    // emits the brand.
     const errorPrototype = Object.getPrototypeOf(error);
 
     return (

--- a/packages/conjure-client/src/errors/error.ts
+++ b/packages/conjure-client/src/errors/error.ts
@@ -28,20 +28,15 @@ export enum ConjureErrorType {
 }
 
 /**
- * Brand stamped on every {@link ConjureError} instance so {@link isConjureError} can recognise errors
- * thrown by a *different* copy of conjure-client on the page (e.g. a bundling/dedupe miss), where
- * `instanceof` fails because each copy defines its own `ConjureError` class.
- *
- * It uses `Symbol.for` (the runtime-global symbol registry) rather than `Symbol()` so that every copy
- * resolves this key to the *same* symbol; a plain class-name string would instead be unreliable because
- * minifiers rename classes. Being a symbol, it is also skipped by `JSON.stringify`, `Object.keys`, and
- * `for...in`, so it never leaks into serialized output.
+ * Lets {@link isConjureError} recognise errors from a different copy of conjure-client on the page, where
+ * `instanceof` fails because each copy defines its own `ConjureError` class. `Symbol.for` resolves to the
+ * same symbol across copies; see
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for.
  */
 const CONJURE_ERROR_BRAND = Symbol.for("com.palantir.conjure.ConjureError");
 
 export class ConjureError<E> {
-    // Brands the prototype so isConjureError can detect ConjureErrors from other copies of the library,
-    // without stamping a symbol onto (and cluttering) every instance.
+    // On the prototype rather than the instance, so the brand doesn't clutter every instance.
     public get [CONJURE_ERROR_BRAND](): true {
         return true;
     }
@@ -86,21 +81,18 @@ export function isConjureError(error: unknown): error is ConjureError<unknown> {
         return false;
     }
 
-    // Common case, and the cheapest check: an error from this same copy of the library, matched by its
-    // prototype. Tried first because the cross-copy paths below can only ever add to this result.
+    // Fast path: an error from this same copy of the library.
     if (error instanceof ConjureError) {
         return true;
     }
 
-    // A duplicate copy of the library defines its own `ConjureError` class, so the `instanceof` above
-    // can't see its instances; the shared brand is what lets us recognise them. (See CONJURE_ERROR_BRAND.)
+    // An error from a different copy of the library, recognised by the shared brand. (See CONJURE_ERROR_BRAND.)
     if (typeof error === "object" && CONJURE_ERROR_BRAND in error && error[CONJURE_ERROR_BRAND] === true) {
         return true;
     }
 
-    // Back-compat for errors from copies of conjure-client that predate the brand: fall back to matching
-    // the class name. This is brittle (minifiers mangle class names) and can go once every producer
-    // emits the brand.
+    // Back-compat for copies that predate the brand: match the class name. Brittle (minifiers mangle names)
+    // and removable once every producer emits the brand.
     const errorPrototype = Object.getPrototypeOf(error);
 
     return (


### PR DESCRIPTION
When more than one copy of conjure-client ends up on a page (a bundling or dedupe miss), an error thrown by one copy's client fails `isConjureError` in an app holding the other copy, because `instanceof` compares against a different `ConjureError` class object.

Brand the prototype with a `Symbol.for(...)` registry symbol so every copy resolves the same key, and check that brand in `isConjureError` (in addition to the existing `instanceof` fast path and a legacy class-name fallback). The brand lives on the prototype via a getter, so instances stay pristine and the symbol never leaks into `JSON.stringify`/`Object.keys`/spread.

### Known limitation: doesn't cross agent boundaries

  This fix recognises ConjureErrors thrown by a different copy of conjure-client in the same JS agent (the common bundling/dedupe miss, and same-origin iframes). It does not work across an agent boundary — notably cross-origin iframes and Web/Service Workers (also Node worker_threads / separate processes).

  Two independent reasons, neither fixable by a different branding scheme:

  1. Symbol.for registry is per-agent. The global symbol registry is shared across realms within one agent, so every copy in the same agent resolves Symbol.for("com.palantir.conjure.ConjureError") to the same symbol. A separate agent (worker, cross-origin iframe) has its own registry, so the symbols aren't equal.
  2. You can't pass a live ConjureError across an agent boundary anyway. Doing so requires postMessage/structuredClone, which drops the prototype and strips all symbol-keyed properties. The received value is a plain object — so instanceof, the symbol brand, and the constructor.name fallback all fail regardless. Only own string data properties survive a structured clone.
