### PR TITLE
Add Conjure compliant deserialization engine

### DIFF
--- a/packages/conjure-client/src/deserialize/__tests__/deserializeTests.ts
+++ b/packages/conjure-client/src/deserialize/__tests__/deserializeTests.ts
@@ -1,0 +1,451 @@
+/**
+ * @license
+ * Copyright 2026 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConjureDeserializeError, deserialize } from "../deserialize";
+import {
+    alias,
+    anyType,
+    booleanType,
+    datetime,
+    double,
+    enumType,
+    integer,
+    list,
+    map,
+    object,
+    optional,
+    reference,
+    rid,
+    safelong,
+    set,
+    stringType,
+    union,
+    uuid,
+} from "../types";
+
+function expectError(fn: () => unknown, pathFragment: string): void {
+    let caught: unknown;
+    try {
+        fn();
+    } catch (e) {
+        caught = e;
+    }
+    expect(caught).toBeInstanceOf(ConjureDeserializeError);
+    expect((caught as ConjureDeserializeError).path).toContain(pathFragment);
+}
+
+// ---------------------------------------------------------------------------
+// optional
+// ---------------------------------------------------------------------------
+describe("optional", () => {
+    const optStr = optional(stringType());
+
+    it("returns undefined for null", () => {
+        expect(deserialize(optStr, null)).toBeUndefined();
+    });
+
+    it("returns undefined for undefined", () => {
+        expect(deserialize(optStr, undefined)).toBeUndefined();
+    });
+
+    it("recurses into present value", () => {
+        expect(deserialize(optStr, "hello")).toBe("hello");
+    });
+
+    it("propagates errors on bad inner type", () => {
+        expectError(() => deserialize(optStr, 42), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// list / set
+// ---------------------------------------------------------------------------
+describe("list", () => {
+    const listInt = list(integer());
+
+    it("returns [] for null", () => {
+        expect(deserialize(listInt, null)).toEqual([]);
+    });
+
+    it("returns [] for undefined", () => {
+        expect(deserialize(listInt, undefined)).toEqual([]);
+    });
+
+    it("maps elements", () => {
+        expect(deserialize(listInt, [1, 2, 3])).toEqual([1, 2, 3]);
+    });
+
+    it("throws on non-array", () => {
+        expectError(() => deserialize(listInt, "oops"), "");
+    });
+
+    it("includes element index in error path", () => {
+        expectError(() => deserialize(listInt, [1, "bad", 3]), "[1]");
+    });
+});
+
+describe("set", () => {
+    const setStr = set(stringType());
+
+    it("returns [] for null", () => {
+        expect(deserialize(setStr, null)).toEqual([]);
+    });
+
+    it("deserializes to an array", () => {
+        expect(deserialize(setStr, ["a", "b"])).toEqual(["a", "b"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// map
+// ---------------------------------------------------------------------------
+describe("map", () => {
+    const mapStrInt = map(integer());
+
+    it("returns {} for null", () => {
+        expect(deserialize(mapStrInt, null)).toEqual({});
+    });
+
+    it("returns {} for undefined", () => {
+        expect(deserialize(mapStrInt, undefined)).toEqual({});
+    });
+
+    it("deserializes values", () => {
+        expect(deserialize(mapStrInt, { a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
+    });
+
+    it("preserves string keys", () => {
+        const result = deserialize<Record<string, number>>(mapStrInt, { foo: 42 });
+        expect(Object.keys(result)).toEqual(["foo"]);
+    });
+
+    it("includes key in error path on bad value", () => {
+        expectError(() => deserialize(mapStrInt, { a: "bad" }), '["a"]');
+    });
+
+    it("throws on non-object", () => {
+        expectError(() => deserialize(mapStrInt, [1, 2]), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// object
+// ---------------------------------------------------------------------------
+describe("object", () => {
+    const recipeType = object({
+        name: stringType(),
+        servings: integer(),
+        notes: optional(stringType()),
+        tags: list(stringType()),
+    });
+
+    it("deserializes fully populated object", () => {
+        const result = deserialize(recipeType, { name: "Soup", servings: 4, notes: "hot", tags: ["lunch"] });
+        expect(result).toEqual({ name: "Soup", servings: 4, notes: "hot", tags: ["lunch"] });
+    });
+
+    it("absent optional field → undefined", () => {
+        const result = deserialize<any>(recipeType, { name: "Soup", servings: 2, tags: [] });
+        expect(result.notes).toBeUndefined();
+    });
+
+    it("absent list field → []", () => {
+        const result = deserialize<any>(recipeType, { name: "Soup", servings: 2 });
+        expect(result.tags).toEqual([]);
+    });
+
+    it("throws on null object", () => {
+        expectError(() => deserialize(recipeType, null), "");
+    });
+
+    it("throws on absent required string with path", () => {
+        expectError(() => deserialize(recipeType, { servings: 1, tags: [] }), "name");
+    });
+
+    it("throws on absent required integer with path", () => {
+        expectError(() => deserialize(recipeType, { name: "X", tags: [] }), "servings");
+    });
+
+    it("ignores unknown keys", () => {
+        const result = deserialize<any>(recipeType, { name: "X", servings: 1, tags: [], extra: "ignored" });
+        expect((result as any).extra).toBeUndefined();
+    });
+
+    it("includes nested path in error", () => {
+        const nested = object({ inner: object({ val: integer() }) });
+        expectError(() => deserialize(nested, { inner: { val: "bad" } }), "inner.val");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// union
+// ---------------------------------------------------------------------------
+describe("union", () => {
+    const shapeType = union({
+        circle: object({ radius: double() }),
+        rect: object({ width: integer(), height: integer() }),
+    });
+
+    it("deserializes known variant", () => {
+        const result = deserialize(shapeType, { type: "circle", circle: { radius: 3.14 } });
+        expect(result).toEqual({ type: "circle", circle: { radius: 3.14 } });
+    });
+
+    it("passes through unknown variant unchanged", () => {
+        const raw = { type: "triangle", triangle: { sides: 3 } };
+        expect(deserialize(shapeType, raw)).toEqual(raw);
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(shapeType, null), "");
+    });
+
+    it("throws when 'type' discriminant is missing", () => {
+        expectError(() => deserialize(shapeType, { circle: { radius: 1 } }), "");
+    });
+
+    it("throws when 'type' discriminant is not a string", () => {
+        expectError(() => deserialize(shapeType, { type: 42, circle: {} }), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// enum
+// ---------------------------------------------------------------------------
+describe("enum", () => {
+    const colorType = enumType();
+
+    it("passes through known string value", () => {
+        expect(deserialize(colorType, "RED")).toBe("RED");
+    });
+
+    it("tolerates unknown string value", () => {
+        expect(deserialize(colorType, "ULTRAVIOLET")).toBe("ULTRAVIOLET");
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(colorType, null), "");
+    });
+
+    it("throws on non-string", () => {
+        expectError(() => deserialize(colorType, 1), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// primitives — no-cast rule (§5.6.2)
+// ---------------------------------------------------------------------------
+describe("primitive: boolean", () => {
+    it("accepts true / false", () => {
+        expect(deserialize(booleanType(), true)).toBe(true);
+        expect(deserialize(booleanType(), false)).toBe(false);
+    });
+
+    it("rejects string 'true' (no cast)", () => {
+        expectError(() => deserialize(booleanType(), "true"), "");
+    });
+
+    it("rejects number 1", () => {
+        expectError(() => deserialize(booleanType(), 1), "");
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(booleanType(), null), "");
+    });
+});
+
+describe("primitive: integer", () => {
+    it("accepts values within 32-bit signed range", () => {
+        expect(deserialize(integer(), 0)).toBe(0);
+        expect(deserialize(integer(), 42)).toBe(42);
+        expect(deserialize(integer(), -2147483648)).toBe(-2147483648);
+        expect(deserialize(integer(), 2147483647)).toBe(2147483647);
+    });
+
+    it("rejects values outside 32-bit range", () => {
+        expectError(() => deserialize(integer(), 2147483648), "");
+        expectError(() => deserialize(integer(), -2147483649), "");
+    });
+
+    it("rejects non-integer floats", () => {
+        expectError(() => deserialize(integer(), 3.14), "");
+    });
+
+    it("rejects string", () => {
+        expectError(() => deserialize(integer(), "42"), "");
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(integer(), null), "");
+    });
+});
+
+describe("primitive: safelong", () => {
+    it("accepts values within safe integer range", () => {
+        expect(deserialize(safelong(), 0)).toBe(0);
+        expect(deserialize(safelong(), Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+        expect(deserialize(safelong(), Number.MIN_SAFE_INTEGER)).toBe(Number.MIN_SAFE_INTEGER);
+    });
+
+    it("rejects values outside safe integer range", () => {
+        expectError(() => deserialize(safelong(), Number.MAX_SAFE_INTEGER + 1), "");
+        expectError(() => deserialize(safelong(), Number.MIN_SAFE_INTEGER - 1), "");
+    });
+
+    it("rejects non-integer floats", () => {
+        expectError(() => deserialize(safelong(), 3.14), "");
+    });
+
+    it("rejects string", () => {
+        expectError(() => deserialize(safelong(), "42"), "");
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(safelong(), null), "");
+    });
+});
+
+describe("primitive: string-like", () => {
+    it("accepts strings", () => {
+        expect(deserialize(stringType(), "hello")).toBe("hello");
+        expect(deserialize(rid(), "ri.x.y.z.1")).toBe("ri.x.y.z.1");
+        expect(deserialize(uuid(), "abc-123")).toBe("abc-123");
+        expect(deserialize(datetime(), "2024-01-01T00:00:00Z")).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("rejects numbers", () => {
+        expectError(() => deserialize(stringType(), 42), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// double
+// ---------------------------------------------------------------------------
+describe("double", () => {
+    const dbl = double();
+
+    it("passes through finite numbers", () => {
+        expect(deserialize(dbl, 3.14)).toBe(3.14);
+        expect(deserialize(dbl, 0)).toBe(0);
+    });
+
+    it("converts 'NaN' string to JS NaN number (§5.1 wire representation)", () => {
+        const result = deserialize<number>(dbl, "NaN");
+        expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it("converts 'Infinity' string to JS Infinity number", () => {
+        expect(deserialize(dbl, "Infinity")).toBe(Infinity);
+    });
+
+    it("converts '-Infinity' string to JS -Infinity number", () => {
+        expect(deserialize(dbl, "-Infinity")).toBe(-Infinity);
+    });
+
+    it("throws on null", () => {
+        expectError(() => deserialize(dbl, null), "");
+    });
+
+    it("throws on other string", () => {
+        expectError(() => deserialize(dbl, "3.14"), "");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// any
+// ---------------------------------------------------------------------------
+describe("any", () => {
+    const anyDescriptor = anyType();
+
+    it("returns value unchanged regardless of shape", () => {
+        expect(deserialize(anyDescriptor, null)).toBeNull();
+        expect(deserialize(anyDescriptor, { x: 1 })).toEqual({ x: 1 });
+        expect(deserialize(anyDescriptor, [1, 2, 3])).toEqual([1, 2, 3]);
+        expect(deserialize(anyDescriptor, undefined)).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// alias — transparent
+// ---------------------------------------------------------------------------
+describe("alias", () => {
+    it("delegates to the aliased type transparently", () => {
+        const strAlias = alias(stringType());
+        expect(deserialize(strAlias, "hello")).toBe("hello");
+        expectError(() => deserialize(strAlias, 42), "");
+    });
+
+    it("chains aliases", () => {
+        const inner = alias(integer());
+        const outer = alias(inner);
+        expect(deserialize(outer, 7)).toBe(7);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// reference — lazy thunk for recursion
+// ---------------------------------------------------------------------------
+describe("reference", () => {
+    // Build a self-referential type: linked list node
+    interface INode {
+        value: number;
+        next?: INode;
+    }
+    // eslint-disable-next-line prefer-const
+    let nodeType: ReturnType<typeof object>;
+    const nodeRef = reference(() => nodeType);
+    nodeType = object({ value: integer(), next: optional(nodeRef) });
+
+    it("resolves thunk and deserializes recursive structure", () => {
+        const json = { value: 1, next: { value: 2, next: { value: 3 } } };
+        const result = deserialize<INode>(nodeType, json);
+        expect(result.value).toBe(1);
+        expect(result.next!.value).toBe(2);
+        expect(result.next!.next!.value).toBe(3);
+        expect(result.next!.next!.next).toBeUndefined();
+    });
+
+    it("includes deep path in error for recursive type", () => {
+        expectError(() => deserialize(nodeType, { value: 1, next: { value: "bad" } }), "next.value");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// nested structures (integration)
+// ---------------------------------------------------------------------------
+describe("nested structures", () => {
+    it("handles list of objects with optional fields", () => {
+        const itemType = object({ id: stringType(), count: optional(integer()) });
+        const containerType = object({ items: list(itemType) });
+
+        const result = deserialize<any>(containerType, {
+            items: [{ id: "a", count: 3 }, { id: "b" }],
+        });
+        expect(result.items[0]).toEqual({ id: "a", count: 3 });
+        expect(result.items[1]).toEqual({ id: "b", count: undefined });
+    });
+
+    it("handles map of list", () => {
+        const t = map(list(integer()));
+        expect(deserialize(t, { x: [1, 2], y: [3] })).toEqual({ x: [1, 2], y: [3] });
+    });
+
+    it("error path includes list index and object field", () => {
+        const t = object({ rows: list(object({ val: integer() })) });
+        expectError(() => deserialize(t, { rows: [{ val: 1 }, { val: "bad" }] }), "rows[1].val");
+    });
+});

--- a/packages/conjure-client/src/deserialize/deserialize.ts
+++ b/packages/conjure-client/src/deserialize/deserialize.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2026 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConjureType } from "./types";
+
+/**
+ * Thrown when {@link deserialize} encounters a value that does not conform to the
+ * expected Conjure wire format (§5.6.1). The {@link path} field contains the
+ * dot/bracket path to the offending location in the JSON (e.g. `"recipe.ingredients[2].name"`).
+ */
+export class ConjureDeserializeError extends Error {
+    public readonly path: string;
+
+    constructor(path: string, detail: string) {
+        super(`Deserialization error at "${path || "<root>"}": ${detail}`);
+        this.path = path;
+        Object.setPrototypeOf(this, ConjureDeserializeError.prototype);
+    }
+}
+
+/**
+ * Applies Conjure §5.6.1 coercions to a raw JSON value according to the given type descriptor.
+ *
+ * Key behaviours:
+ *  - `optional` — `null` / `undefined` / absent key → `undefined`; otherwise recurse.
+ *  - `list` / `set` — `null` / `undefined` → `[]`; otherwise validates and maps elements.
+ *  - `map`  — `null` / `undefined` → `{}`; otherwise validates and maps values.
+ *  - `object` — required fields that are absent/null delegate to the field's own type rule.
+ *  - `union` — unknown variant passes through unchanged (§4.4 forward-compat).
+ *  - `double` — passes through `number` values AND the strings `"NaN"`, `"Infinity"`, `"-Infinity"`.
+ *  - primitives — validates `typeof`; does NOT cast (§5.6.2: `"true"` is not `boolean`).
+ *  - `any` — returned as-is with no validation.
+ */
+export function deserialize<T = unknown>(type: ConjureType, json: unknown): T {
+    return deserializeAt(type, json, "") as T;
+}
+
+function deserializeAt(type: ConjureType, json: unknown, path: string): unknown {
+    switch (type.kind) {
+        case "optional":
+            return json == null ? undefined : deserializeAt(type.item, json, path);
+
+        case "list":
+        case "set":
+            if (json == null) {
+                return [];
+            }
+            if (!Array.isArray(json)) {
+                throw new ConjureDeserializeError(path, `expected array, got ${typeof json}`);
+            }
+            return json.map((item, i) => deserializeAt(type.item, item, `${path}[${i}]`));
+
+        case "map": {
+            if (json == null) {
+                return {};
+            }
+            if (typeof json !== "object" || Array.isArray(json)) {
+                throw new ConjureDeserializeError(path, `expected object for map, got ${typeof json}`);
+            }
+            const out: Record<string, unknown> = {};
+            for (const key of Object.keys(json as object)) {
+                out[key] = deserializeAt(type.value, (json as Record<string, unknown>)[key], `${path}["${key}"]`);
+            }
+            return out;
+        }
+
+        case "object": {
+            if (json == null) {
+                throw new ConjureDeserializeError(path, "expected object, got null or undefined");
+            }
+            if (typeof json !== "object" || Array.isArray(json)) {
+                throw new ConjureDeserializeError(path, `expected object, got ${typeof json}`);
+            }
+            const out: Record<string, unknown> = {};
+            for (const [fieldName, fieldType] of Object.entries(type.fields)) {
+                const fieldPath = path.length > 0 ? `${path}.${fieldName}` : fieldName;
+                out[fieldName] = deserializeAt(fieldType, (json as Record<string, unknown>)[fieldName], fieldPath);
+                // Unknown keys in the JSON object are intentionally ignored (§4.1 forward-compat).
+            }
+            return out;
+        }
+
+        case "union": {
+            if (json == null) {
+                throw new ConjureDeserializeError(path, "expected union object, got null or undefined");
+            }
+            if (typeof json !== "object" || Array.isArray(json)) {
+                throw new ConjureDeserializeError(path, `expected object for union, got ${typeof json}`);
+            }
+            const unionJson = json as Record<string, unknown>;
+            const variant = unionJson.type;
+            if (typeof variant !== "string") {
+                throw new ConjureDeserializeError(path, "union missing string 'type' discriminant");
+            }
+            const variantType = type.variants[variant];
+            if (variantType == null) {
+                // Unknown variant — pass through unchanged per §4.4 forward-compat.
+                return json;
+            }
+            return {
+                type: variant,
+                [variant]: deserializeAt(variantType, unionJson[variant], `${path}.${variant}`),
+            };
+        }
+
+        case "enum":
+            if (json == null) {
+                throw new ConjureDeserializeError(path, "expected enum string, got null or undefined");
+            }
+            if (typeof json !== "string") {
+                throw new ConjureDeserializeError(path, `expected string for enum, got ${typeof json}`);
+            }
+            // Unknown enum values are tolerated (§4.3 forward-compat).
+            return json;
+
+        case "primitive":
+            if (json == null) {
+                throw new ConjureDeserializeError(path, `expected ${type.type}, got null or undefined`);
+            }
+            switch (type.type) {
+                case "string":
+                case "rid":
+                case "uuid":
+                case "bearertoken":
+                case "binary":
+                case "datetime":
+                    if (typeof json !== "string") {
+                        throw new ConjureDeserializeError(path, `expected string, got ${typeof json}`);
+                    }
+                    return json;
+                case "boolean":
+                    if (typeof json !== "boolean") {
+                        throw new ConjureDeserializeError(path, `expected boolean, got ${typeof json}`);
+                    }
+                    return json;
+                case "integer":
+                    if (
+                        typeof json !== "number" ||
+                        !Number.isInteger(json) ||
+                        json < -2147483648 ||
+                        json > 2147483647
+                    ) {
+                        throw new ConjureDeserializeError(
+                            path,
+                            `expected 32-bit signed integer, got ${JSON.stringify(json)}`,
+                        );
+                    }
+                    return json;
+                case "safelong":
+                    if (typeof json !== "number" || !Number.isSafeInteger(json)) {
+                        throw new ConjureDeserializeError(
+                            path,
+                            `expected safelong (integer in range -(2^53-1) to 2^53-1), got ${JSON.stringify(json)}`,
+                        );
+                    }
+                    return json;
+            }
+
+        // The exhaustive-switch lint rule is satisfied by the union above.
+        // eslint-disable-next-line no-fallthrough
+        case "double":
+            if (json == null) {
+                throw new ConjureDeserializeError(path, "expected double, got null or undefined");
+            }
+            if (typeof json === "number") {
+                return json;
+            }
+            // §5.1: "NaN", "Infinity", "-Infinity" are the wire representations of the non-finite IEEE 754 values.
+            // Convert to actual JS numbers so the return type is always `number`.
+            if (json === "NaN") {
+                return NaN;
+            }
+            if (json === "Infinity") {
+                return Infinity;
+            }
+            if (json === "-Infinity") {
+                return -Infinity;
+            }
+            throw new ConjureDeserializeError(
+                path,
+                `expected number or one of "NaN", "Infinity", "-Infinity", got ${JSON.stringify(json)}`,
+            );
+
+        case "any":
+            return json;
+
+        case "alias":
+            return deserializeAt(type.aliased, json, path);
+
+        case "reference":
+            return deserializeAt(type.resolve(), json, path);
+    }
+}

--- a/packages/conjure-client/src/deserialize/types.ts
+++ b/packages/conjure-client/src/deserialize/types.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Discriminated-union type descriptor mirroring the Conjure wire spec §5.1–5.4.
+ * Used by {@link deserialize} to apply §5.6.1 coercions to raw JSON responses.
+ *
+ * Build descriptor values with the provided builder functions rather than constructing
+ * the union directly.
+ */
+export type ConjureType =
+    | {
+          kind: "primitive";
+          type: "string" | "boolean" | "integer" | "safelong" | "rid" | "uuid" | "bearertoken" | "binary" | "datetime";
+      }
+    | { kind: "double" }
+    | { kind: "any" }
+    | { kind: "enum" }
+    | { kind: "optional"; item: ConjureType }
+    | { kind: "list"; item: ConjureType }
+    | { kind: "set"; item: ConjureType }
+    | { kind: "map"; value: ConjureType }
+    | { kind: "object"; fields: Record<string, ConjureType> }
+    | { kind: "union"; variants: Record<string, ConjureType> }
+    | { kind: "alias"; aliased: ConjureType }
+    /** Lazy thunk — allows mutually-recursive descriptors without forward-reference issues. */
+    | { kind: "reference"; resolve: () => ConjureType };
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+export const stringType = (): ConjureType => ({ kind: "primitive", type: "string" });
+export const booleanType = (): ConjureType => ({ kind: "primitive", type: "boolean" });
+export const integer = (): ConjureType => ({ kind: "primitive", type: "integer" });
+export const safelong = (): ConjureType => ({ kind: "primitive", type: "safelong" });
+export const rid = (): ConjureType => ({ kind: "primitive", type: "rid" });
+export const uuid = (): ConjureType => ({ kind: "primitive", type: "uuid" });
+export const bearertoken = (): ConjureType => ({ kind: "primitive", type: "bearertoken" });
+export const binary = (): ConjureType => ({ kind: "primitive", type: "binary" });
+export const datetime = (): ConjureType => ({ kind: "primitive", type: "datetime" });
+export const double = (): ConjureType => ({ kind: "double" });
+export const anyType = (): ConjureType => ({ kind: "any" });
+export const enumType = (): ConjureType => ({ kind: "enum" });
+export const optional = (item: ConjureType): ConjureType => ({ kind: "optional", item });
+export const list = (item: ConjureType): ConjureType => ({ kind: "list", item });
+export const set = (item: ConjureType): ConjureType => ({ kind: "set", item });
+export const map = (value: ConjureType): ConjureType => ({ kind: "map", value });
+export const object = (fields: Record<string, ConjureType>): ConjureType => ({ kind: "object", fields });
+export const union = (variants: Record<string, ConjureType>): ConjureType => ({ kind: "union", variants });
+export const alias = (aliased: ConjureType): ConjureType => ({ kind: "alias", aliased });
+export const reference = (resolve: () => ConjureType): ConjureType => ({ kind: "reference", resolve });

--- a/packages/conjure-client/src/index.ts
+++ b/packages/conjure-client/src/index.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+export * from "./deserialize/deserialize";
+export * from "./deserialize/types";
 export * from "./errors";
 export * from "./fetchBridge";
 export { FetchBridge as DefaultHttpApiBridge } from "./fetchBridge";


### PR DESCRIPTION
## Summary

Adds a schema-driven deserialization engine to `conjure-client` implementing the Conjure wire spec §5.6, motivated by and addressing palantir/conjure-typescript#48, #78, #156.

### New exports from `conjure-client`
- `ConjureType` — discriminated union type descriptor + builder functions (`string()`, `list(item)`, `object(fields)`, `union(variants)`, etc.)
- `deserialize<T>(type, json)` — applies §5.6 coercions recursively
- `ConjureDeserializeError` — thrown on violations, carries the dot/bracket JSON path to the failing field

### §5.6 behaviours implemented
- `optional` null/absent → `undefined` (addresses #156: standardise on `undefined` not `null`)
- `list`/`set`/`map` null → empty collection (addresses #78: null collections from server)
- Required field null/absent → `ConjureDeserializeError`
- `integer` — validates 32-bit signed range and integrality (§5.1)
- `safelong` — validates `Number.isSafeInteger()` range ±(2^53−1) (§5.1)
- `double` — converts `"NaN"`/`"Infinity"`/`"-Infinity"` wire strings to actual JS `number` values (addresses #48: ergonomic double handling)
- `boolean` — rejects `"true"` string, no implicit cast (§5.6.2)
- `union` unknown variant → pass through unchanged (§4.4 forward-compat)
- `enum` unknown value → pass through as string (§4.1 forward-compat)
- Unknown object fields → ignored (§4.1 forward-compat)

### Design
The engine is schema-driven: callers supply a `ConjureType` descriptor built from the builder functions. The companion PR (palantir/conjure-typescript#396) generates `_TypeName` descriptor constants for every type and wires them into service calls automatically when `--useDeserializer` is set. Flag is opt-in and default-off — no impact on existing code.

## Test plan
- [ ] `yarn test` passes in `packages/conjure-client`
- [ ] Verify `deserialize` and `ConjureType` builders are re-exported from the package root

🤖 Generated with [Claude Code](https://claude.com/claude-code)