### PR TITLE
Update changelog to use default repo type

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,5 +1,3 @@
+# Excavator auto-updates this file. Please contribute improvements to the central template.
 repo-type:
-  type: lernaMonoRepo
-  lernaMonoRepo:
-    changelogDirectories:
-      - packages/conjure-client
+  type: default


### PR DESCRIPTION
This repo releases a single monoversion and not PNPM package versions, it should not use the monorepo type which is inferred by default from changelog